### PR TITLE
fix(agents): rebuild chat-assistant widget with real internal components

### DIFF
--- a/features/agents/components/agent-widgets/chat-assistant/AgentChatAssistant.tsx
+++ b/features/agents/components/agent-widgets/chat-assistant/AgentChatAssistant.tsx
@@ -1,5 +1,19 @@
 "use client";
 
+/**
+ * AgentChatAssistant
+ *
+ * Floating chat assistant widget for testing agent execution instances.
+ *
+ * DESIGN: Transparent floating panel — messages appear as detached, independently
+ * floating items with no container card background. The panel uses a subtle
+ * backdrop blur for the chrome (header + input) while the message area is
+ * fully transparent.
+ *
+ * WIDTH: 320px — balances content readability (markdown, artifacts) with
+ * compact space usage in the sidebar test environment.
+ */
+
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useAppSelector } from "@/lib/redux/hooks";
 import {
@@ -13,7 +27,7 @@ import { AssistantCardStack } from "./AssistantCardStack";
 import { CompactAssistantInput } from "./CompactAssistantInput";
 import { AssistantControlBar } from "./AssistantControlBar";
 import { useAssistantHeartbeat } from "./useAssistantHeartbeat";
-import { X } from "lucide-react";
+import { X, GripHorizontal } from "lucide-react";
 
 interface AgentChatAssistantProps {
   conversationId: string;
@@ -97,10 +111,11 @@ export function AgentChatAssistant({
     setTimeout(onClose, 300);
   }, [onClose]);
 
-  if (needsPreExecution) return <ExecutionManager conversationId={conversationId} />;
+  if (needsPreExecution)
+    return <ExecutionManager conversationId={conversationId} />;
 
   const bottomOffset = 16 + stackIndex * 56;
-  const rightOffset = 16 + stackIndex * 320;
+  const rightOffset = 16 + stackIndex * 340;
 
   return (
     <div
@@ -114,28 +129,29 @@ export function AgentChatAssistant({
         zIndex: 200 + stackIndex,
       }}
     >
-      {/* Card panel — visible when open */}
+      {/* Panel — visible when open */}
       {isOpen && (
         <div className="mb-2 animate-in slide-in-from-bottom-4 fade-in-0 duration-300">
-          <div className="w-72 max-h-[70vh] bg-card border border-border rounded-xl shadow-2xl overflow-hidden flex flex-col">
-            {/* Header — draggable */}
+          <div className="w-80 max-h-[75vh] rounded-xl overflow-hidden flex flex-col shadow-2xl border border-border/50 bg-background/80 backdrop-blur-xl">
+            {/* Header — draggable, minimal chrome */}
             <div
-              className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30 cursor-grab active:cursor-grabbing touch-none select-none shrink-0"
+              className="flex items-center justify-between px-3 py-1.5 border-b border-border/40 cursor-grab active:cursor-grabbing touch-none select-none shrink-0 bg-muted/20"
               onPointerDown={handlePointerDown}
               onPointerMove={handlePointerMove}
               onPointerUp={handlePointerUp}
             >
               <div className="flex items-center gap-2 min-w-0">
+                <GripHorizontal className="w-3 h-3 text-muted-foreground/40 shrink-0" />
                 {isExecuting && (
                   <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse shrink-0" />
                 )}
-                <span className="text-xs font-medium text-foreground truncate">
+                <span className="text-[11px] font-medium text-foreground/80 truncate">
                   {title}
                 </span>
               </div>
               <div className="shrink-0" data-no-drag>
                 <button
-                  className="p-1 rounded-md hover:bg-muted transition-colors"
+                  className="p-0.5 rounded-md hover:bg-muted transition-colors"
                   onClick={handleDismiss}
                 >
                   <X className="w-3 h-3 text-muted-foreground" />
@@ -143,10 +159,10 @@ export function AgentChatAssistant({
               </div>
             </div>
 
-            {/* Card stack */}
+            {/* Message stack — transparent background */}
             <AssistantCardStack conversationId={conversationId} />
 
-            {/* Compact input */}
+            {/* Compact input with controls */}
             <CompactAssistantInput conversationId={conversationId} />
           </div>
         </div>

--- a/features/agents/components/agent-widgets/chat-assistant/AssistantCardStack.tsx
+++ b/features/agents/components/agent-widgets/chat-assistant/AssistantCardStack.tsx
@@ -27,6 +27,7 @@ import {
   selectConversationMode,
 } from "@/features/agents/redux/execution-system/selectors/aggregate.selectors";
 import { selectInstanceVariableDefinitions } from "@/features/agents/redux/execution-system/instance-variable-values/instance-variable-values.selectors";
+import { selectShowVariablePanel } from "@/features/agents/redux/execution-system/instance-ui-state/instance-ui-state.selectors";
 import { executeInstance } from "@/features/agents/redux/execution-system/thunks/execute-instance.thunk";
 import { executeChatInstance } from "@/features/agents/redux/execution-system/thunks/execute-chat-instance.thunk";
 import { AgentUserMessage } from "../../run/AgentUserMessage";
@@ -82,6 +83,9 @@ export function AssistantCardStack({
   );
   const conversationMode = useAppSelector(
     selectConversationMode(conversationId),
+  );
+  const showVariablePanel = useAppSelector(
+    selectShowVariablePanel(conversationId),
   );
 
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -153,11 +157,13 @@ export function AssistantCardStack({
 
   const hasVariables = variableDefs.length > 0;
   const hasMessages = displayMessages.length > 0;
+  // Show variables when: agent has them AND (panel toggle is on OR no messages yet)
+  const showVariables = hasVariables && (showVariablePanel || !hasMessages);
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto scroll-smooth flex flex-col">
-      {/* Variable inputs — always visible when agent has variables */}
-      {hasVariables && (
+      {/* Variable inputs — visible via toggle or before first message */}
+      {showVariables && (
         <div className="shrink-0">
           <ChatAssistantVariableInputs
             conversationId={conversationId}

--- a/features/agents/components/agent-widgets/chat-assistant/AssistantCardStack.tsx
+++ b/features/agents/components/agent-widgets/chat-assistant/AssistantCardStack.tsx
@@ -1,121 +1,231 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+/**
+ * AssistantCardStack
+ *
+ * Core message display for the chat assistant widget.
+ *
+ * CRITICAL: Uses the real AgentAssistantMessage (which renders via MarkdownStream
+ * with full artifact/block support) and AgentUserMessage — not simplified card
+ * components. This preserves the 100k+ lines of rendering logic inside those
+ * components while wrapping them in the chat assistant's compact, transparent layout.
+ *
+ * DESIGN: Messages render as transparent, detached floating items with spacing.
+ * No container card backgrounds. The unified displayMessages pattern from
+ * AgentConversationDisplay ensures streaming messages never unmount.
+ */
+
+import { useEffect, useRef, useMemo } from "react";
+import dynamic from "next/dynamic";
 import { useAppSelector, useAppDispatch } from "@/lib/redux/hooks";
 import { selectConversationTurns } from "@/features/agents/redux/execution-system/instance-conversation-history/instance-conversation-history.selectors";
 import {
   selectStreamPhase,
   selectLatestAccumulatedText,
-  selectShouldShowVariables,
+  selectLatestInfoUserMessage,
+  selectLatestError,
+  selectConversationMode,
 } from "@/features/agents/redux/execution-system/selectors/aggregate.selectors";
-import {
-  selectInstanceVariableDefinitions,
-  selectUserVariableValues,
-} from "@/features/agents/redux/execution-system/instance-variable-values/instance-variable-values.selectors";
-import { selectConversationMode } from "@/features/agents/redux/execution-system/selectors/aggregate.selectors";
+import { selectInstanceVariableDefinitions } from "@/features/agents/redux/execution-system/instance-variable-values/instance-variable-values.selectors";
 import { executeInstance } from "@/features/agents/redux/execution-system/thunks/execute-instance.thunk";
 import { executeChatInstance } from "@/features/agents/redux/execution-system/thunks/execute-chat-instance.thunk";
-import { AssistantMessageCard } from "./AssistantMessageCard";
-import { UserMessageCard } from "./UserMessageCard";
-import { StatusCard } from "./StatusCard";
-import { VariableInputCard } from "./VariableInputCard";
+import { AgentUserMessage } from "../../run/AgentUserMessage";
+import { AgentPlanningIndicator } from "../../run/AgentPlanningIndicator";
+import { AgentStatusIndicator } from "../../run/AgentStatusIndicator";
+import { ChatAssistantVariableInputs } from "./ChatAssistantVariableInputs";
+
+const AgentAssistantMessage = dynamic(
+  () =>
+    import("../../run/AgentAssistantMessage").then((m) => ({
+      default: m.AgentAssistantMessage,
+    })),
+  { ssr: false },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface DisplayMessage {
+  key: string;
+  role: "user" | "assistant" | "system" | "status";
+  content: string;
+  contentBlocks?: Array<Record<string, unknown>>;
+  isStreamActive: boolean;
+  error?: string | null;
+  infoMessage?: string | null;
+}
 
 interface AssistantCardStackProps {
   conversationId: string;
 }
 
-export function AssistantCardStack({ conversationId }: AssistantCardStackProps) {
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function AssistantCardStack({
+  conversationId,
+}: AssistantCardStackProps) {
   const dispatch = useAppDispatch();
   const turns = useAppSelector(selectConversationTurns(conversationId));
-  const streamPhase = useAppSelector(selectStreamPhase(conversationId));
-  const streamingText = useAppSelector(selectLatestAccumulatedText(conversationId));
-  const shouldShowVars = useAppSelector(selectShouldShowVariables(conversationId));
+  const phase = useAppSelector(selectStreamPhase(conversationId));
+  const streamingText = useAppSelector(
+    selectLatestAccumulatedText(conversationId),
+  );
+  const infoMessage = useAppSelector(
+    selectLatestInfoUserMessage(conversationId),
+  );
+  const error = useAppSelector(selectLatestError(conversationId));
   const variableDefs = useAppSelector(
     selectInstanceVariableDefinitions(conversationId),
   );
-  const userValues = useAppSelector(selectUserVariableValues(conversationId));
-  const conversationMode = useAppSelector(selectConversationMode(conversationId));
+  const conversationMode = useAppSelector(
+    selectConversationMode(conversationId),
+  );
 
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  // ── Stream state ────────────────────────────────────────────────────────────
+  const isActive =
+    phase === "connecting" ||
+    phase === "pre_token" ||
+    phase === "text_streaming" ||
+    phase === "interstitial" ||
+    phase === "error";
+
+  // ── Unified display messages (history + live stream) ────────────────────────
+  // This pattern (from AgentConversationDisplay) ensures the streaming message
+  // never unmounts when the stream completes and the turn is committed.
+  const displayMessages = useMemo((): DisplayMessage[] => {
+    const msgs: DisplayMessage[] = turns.map((turn) => ({
+      key: turn.turnId,
+      role: turn.role,
+      content: turn.content,
+      contentBlocks: turn.contentBlocks,
+      isStreamActive: false,
+      ...(turn.errorMessage && { error: turn.errorMessage }),
+    }));
+
+    if (isActive) {
+      if (phase === "connecting" || phase === "pre_token") {
+        msgs.push({
+          key: "__streaming__",
+          role: "status",
+          content: "",
+          isStreamActive: true,
+        });
+      } else if (phase === "text_streaming" || phase === "interstitial") {
+        msgs.push({
+          key: "__streaming__",
+          role: "assistant",
+          content: streamingText ?? "",
+          isStreamActive: true,
+          infoMessage: phase === "interstitial" ? infoMessage : null,
+        });
+      } else if (phase === "error") {
+        msgs.push({
+          key: "__streaming__",
+          role: "assistant",
+          content: streamingText ?? "",
+          isStreamActive: false,
+          error: error ?? "An error occurred during streaming.",
+        });
+      }
     }
-  }, [turns.length, streamingText]);
 
+    return msgs;
+  }, [turns, isActive, phase, streamingText, infoMessage, error]);
+
+  // ── Auto-scroll on new messages ─────────────────────────────────────────────
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [displayMessages.length, isActive]);
+
+  // ── Variable submit handler ─────────────────────────────────────────────────
   const handleVariableSubmit = () => {
     if (conversationMode === "chat") {
-      dispatch(executeChatInstance({ conversationId: conversationId }));
+      dispatch(executeChatInstance({ conversationId }));
     } else {
       dispatch(executeInstance({ conversationId }));
     }
   };
 
-  const isActiveStream =
-    streamPhase === "text_streaming" ||
-    streamPhase === "reasoning" ||
-    streamPhase === "interstitial";
-
-  const isConnecting =
-    streamPhase === "connecting" || streamPhase === "pre_token";
-
-  const unfilledVars = shouldShowVars
-    ? variableDefs.filter((def) => {
-        const val = userValues[def.name];
-        return val === undefined || val === null || val === "";
-      })
-    : [];
+  const hasVariables = variableDefs.length > 0;
+  const hasMessages = displayMessages.length > 0;
 
   return (
-    <div
-      ref={scrollRef}
-      className="flex-1 min-h-[120px] overflow-y-auto px-2 py-2 space-y-2 scroll-smooth"
-    >
-      {/* Variable input cards (shown before first execution) */}
-      {unfilledVars.map((variable) => (
-        <VariableInputCard
-          key={variable.name}
-          conversationId={conversationId}
-          variable={variable}
-          onSubmit={handleVariableSubmit}
-        />
-      ))}
+    <div className="flex-1 min-h-0 overflow-y-auto scroll-smooth flex flex-col">
+      {/* Variable inputs — always visible when agent has variables */}
+      {hasVariables && (
+        <div className="shrink-0">
+          <ChatAssistantVariableInputs
+            conversationId={conversationId}
+            onSubmit={handleVariableSubmit}
+          />
+        </div>
+      )}
 
-      {/* Conversation turns */}
-      {turns.map((turn) => {
-        const ts = new Date(turn.timestamp).toLocaleTimeString([], {
-          hour: "2-digit",
-          minute: "2-digit",
-        });
+      {/* Conversation messages — transparent, floating, detached */}
+      {hasMessages ? (
+        <div className="flex-1 space-y-3 px-3 py-2">
+          {displayMessages.map((msg, idx) => {
+            if (msg.role === "user") {
+              return (
+                <AgentUserMessage
+                  key={msg.key}
+                  content={msg.content}
+                  contentBlocks={msg.contentBlocks}
+                  messageIndex={idx}
+                  compact
+                />
+              );
+            }
 
-        if (turn.role === "user") {
-          return (
-            <UserMessageCard
-              key={turn.turnId}
-              content={turn.content}
-              timestamp={ts}
-            />
-          );
-        }
+            if (msg.role === "status") {
+              return (
+                <div key={msg.key} className="px-1 py-1">
+                  <AgentPlanningIndicator compact />
+                </div>
+              );
+            }
 
-        if (turn.role === "assistant") {
-          return (
-            <AssistantMessageCard
-              key={turn.turnId}
-              content={turn.content}
-              timestamp={ts}
-            />
-          );
-        }
+            if (msg.role === "assistant") {
+              return (
+                <div key={msg.key}>
+                  <AgentAssistantMessage
+                    content={msg.content}
+                    messageIndex={idx}
+                    isStreamActive={msg.isStreamActive}
+                    compact
+                    error={msg.error}
+                    conversationId={conversationId}
+                    messageKey={msg.key}
+                  />
+                  {msg.isStreamActive && msg.infoMessage && (
+                    <AgentStatusIndicator
+                      message={msg.infoMessage}
+                      compact
+                    />
+                  )}
+                </div>
+              );
+            }
 
-        return null;
-      })}
+            return null;
+          })}
 
-      {/* Live streaming card */}
-      {isConnecting && <StatusCard phase="connecting" />}
-      {isActiveStream && streamingText && (
-        <AssistantMessageCard content={streamingText} isStreaming />
+          <div ref={bottomRef} />
+        </div>
+      ) : (
+        /* Empty state */
+        !hasVariables && (
+          <div className="flex-1 flex items-center justify-center px-4">
+            <p className="text-xs text-muted-foreground/50 text-center">
+              Send a message to get started
+            </p>
+          </div>
+        )
       )}
     </div>
   );

--- a/features/agents/components/agent-widgets/chat-assistant/ChatAssistantVariableInputs.tsx
+++ b/features/agents/components/agent-widgets/chat-assistant/ChatAssistantVariableInputs.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+/**
+ * ChatAssistantVariableInputs
+ *
+ * Compact, collapsible variable input panel customized for the chat assistant widget.
+ * Shows ALL variable definitions regardless of conversation state.
+ * Minimal row-based layout — no individual card borders.
+ */
+
+import { useState } from "react";
+import { useAppDispatch, useAppSelector } from "@/lib/redux/hooks";
+import { setUserVariableValue } from "@/features/agents/redux/execution-system/instance-variable-values/instance-variable-values.slice";
+import {
+  selectInstanceVariableDefinitions,
+  selectUserVariableValues,
+} from "@/features/agents/redux/execution-system/instance-variable-values/instance-variable-values.selectors";
+import type { VariableDefinition } from "@/features/agents/types/agent-definition.types";
+import { ChevronDown, ChevronRight, Minus, Plus } from "lucide-react";
+import type { AppDispatch } from "@/lib/redux/store";
+
+interface ChatAssistantVariableInputsProps {
+  conversationId: string;
+  onSubmit: () => void;
+}
+
+export function ChatAssistantVariableInputs({
+  conversationId,
+  onSubmit,
+}: ChatAssistantVariableInputsProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const variableDefs = useAppSelector(
+    selectInstanceVariableDefinitions(conversationId),
+  );
+  const userValues = useAppSelector(selectUserVariableValues(conversationId));
+  const dispatch = useAppDispatch();
+
+  if (variableDefs.length === 0) return null;
+
+  const filledCount = variableDefs.filter((def) => {
+    const val = userValues[def.name];
+    return val !== undefined && val !== null && val !== "";
+  }).length;
+
+  return (
+    <div className="border-b border-border/40">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center gap-1.5 px-3 py-1.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {isExpanded ? (
+          <ChevronDown className="w-3 h-3 shrink-0" />
+        ) : (
+          <ChevronRight className="w-3 h-3 shrink-0" />
+        )}
+        <span className="font-medium uppercase tracking-wider">Variables</span>
+        <span className="text-muted-foreground/60 ml-auto">
+          {filledCount}/{variableDefs.length}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className="px-3 pb-2 space-y-1.5">
+          {variableDefs.map((variable) => (
+            <MicroVariableRow
+              key={variable.name}
+              conversationId={conversationId}
+              variable={variable}
+              value={userValues[variable.name]}
+              dispatch={dispatch}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Micro variable row — label + input in one compact line
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface MicroVariableRowProps {
+  conversationId: string;
+  variable: VariableDefinition;
+  value: unknown;
+  dispatch: AppDispatch;
+}
+
+function MicroVariableRow({
+  conversationId,
+  variable,
+  value,
+  dispatch,
+}: MicroVariableRowProps) {
+  const comp = variable.customComponent;
+  const type = comp?.type ?? "textarea";
+
+  const setValue = (v: unknown) => {
+    dispatch(
+      setUserVariableValue({ conversationId, name: variable.name, value: v }),
+    );
+  };
+
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <label className="text-[10px] font-medium text-muted-foreground shrink-0 w-16 truncate" title={variable.name}>
+        {variable.name}
+        {variable.required && <span className="text-destructive">*</span>}
+      </label>
+      <div className="flex-1 min-w-0">
+        {type === "textarea" ? (
+          <MicroText value={(value as string) ?? ""} onChange={setValue} />
+        ) : type === "toggle" ? (
+          <MicroToggle
+            value={value as string}
+            labels={comp?.toggleValues ?? ["On", "Off"]}
+            onChange={setValue}
+          />
+        ) : type === "radio" ? (
+          <MicroChips
+            options={comp?.options ?? []}
+            selected={(value as string) ?? ""}
+            onSelect={setValue}
+            multi={false}
+          />
+        ) : type === "checkbox" ? (
+          <MicroChips
+            options={comp?.options ?? []}
+            selected={(value as string[]) ?? []}
+            onSelect={setValue}
+            multi
+          />
+        ) : type === "select" ? (
+          <MicroSelect
+            options={comp?.options ?? []}
+            value={(value as string) ?? ""}
+            onChange={setValue}
+          />
+        ) : type === "number" ? (
+          <MicroNumber
+            value={(value as number) ?? comp?.min ?? 0}
+            min={comp?.min}
+            max={comp?.max}
+            step={comp?.step ?? 1}
+            onChange={setValue}
+          />
+        ) : (
+          <MicroText value={(value as string) ?? ""} onChange={setValue} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Micro input primitives — ultra compact, no card borders
+// ─────────────────────────────────────────────────────────────────────────────
+
+function MicroText({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <input
+      type="text"
+      className="w-full h-6 px-1.5 text-[11px] bg-muted/40 border border-border/60 rounded focus:outline-none focus:ring-1 focus:ring-primary/40"
+      style={{ fontSize: "16px" }}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="..."
+    />
+  );
+}
+
+function MicroToggle({
+  value,
+  labels,
+  onChange,
+}: {
+  value: unknown;
+  labels: [string, string];
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex gap-0.5">
+      {labels.map((label) => (
+        <button
+          key={label}
+          className={`flex-1 h-6 text-[10px] rounded border transition-colors ${
+            value === label
+              ? "bg-primary text-primary-foreground border-primary"
+              : "bg-muted/40 text-foreground border-border/60 hover:bg-muted"
+          }`}
+          onClick={() => onChange(label)}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function MicroChips({
+  options,
+  selected,
+  onSelect,
+  multi,
+}: {
+  options: string[];
+  selected: string | string[];
+  onSelect: (v: string | string[]) => void;
+  multi: boolean;
+}) {
+  const isSelected = (opt: string) =>
+    multi ? (selected as string[]).includes(opt) : selected === opt;
+
+  const handleClick = (opt: string) => {
+    if (multi) {
+      const arr = Array.isArray(selected) ? selected : [];
+      onSelect(
+        arr.includes(opt) ? arr.filter((o) => o !== opt) : [...arr, opt],
+      );
+    } else {
+      onSelect(opt);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap gap-0.5">
+      {options.map((opt) => (
+        <button
+          key={opt}
+          className={`h-5 px-1.5 text-[9px] rounded border transition-colors ${
+            isSelected(opt)
+              ? "bg-primary text-primary-foreground border-primary"
+              : "bg-muted/40 text-foreground border-border/60 hover:bg-muted"
+          }`}
+          onClick={() => handleClick(opt)}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function MicroSelect({
+  options,
+  value,
+  onChange,
+}: {
+  options: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <select
+      className="w-full h-6 px-1.5 text-[11px] bg-muted/40 border border-border/60 rounded focus:outline-none focus:ring-1 focus:ring-primary/40 appearance-none"
+      style={{ fontSize: "16px" }}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">Select...</option>
+      {options.map((opt) => (
+        <option key={opt} value={opt}>
+          {opt}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function MicroNumber({
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  value: number;
+  min?: number;
+  max?: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  const decrement = () => {
+    const next = value - step;
+    const clamped = min !== undefined ? Math.max(min, next) : next;
+    onChange(clamped);
+  };
+
+  const increment = () => {
+    const next = value + step;
+    const clamped = max !== undefined ? Math.min(max, next) : next;
+    onChange(clamped);
+  };
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <button
+        className="w-5 h-5 flex items-center justify-center rounded bg-muted/40 border border-border/60 hover:bg-muted"
+        onClick={decrement}
+      >
+        <Minus className="w-2.5 h-2.5" />
+      </button>
+      <span className="w-8 text-center text-[10px] font-medium tabular-nums">
+        {value}
+      </span>
+      <button
+        className="w-5 h-5 flex items-center justify-center rounded bg-muted/40 border border-border/60 hover:bg-muted"
+        onClick={increment}
+      >
+        <Plus className="w-2.5 h-2.5" />
+      </button>
+    </div>
+  );
+}

--- a/features/agents/components/agent-widgets/chat-assistant/ChatAssistantVariableInputs.tsx
+++ b/features/agents/components/agent-widgets/chat-assistant/ChatAssistantVariableInputs.tsx
@@ -16,7 +16,8 @@ import {
   selectUserVariableValues,
 } from "@/features/agents/redux/execution-system/instance-variable-values/instance-variable-values.selectors";
 import type { VariableDefinition } from "@/features/agents/types/agent-definition.types";
-import { ChevronDown, ChevronRight, Minus, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, Minus, Plus, Play } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import type { AppDispatch } from "@/lib/redux/store";
 
 interface ChatAssistantVariableInputsProps {
@@ -70,6 +71,17 @@ export function ChatAssistantVariableInputs({
               dispatch={dispatch}
             />
           ))}
+          {/* Run button — lets agents execute with just variables, no text */}
+          <div className="flex justify-end pt-0.5">
+            <Button
+              size="sm"
+              className="h-6 px-2.5 text-[10px] rounded-full gap-1"
+              onClick={onSubmit}
+            >
+              <Play className="w-2.5 h-2.5" />
+              Run
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/features/agents/components/agent-widgets/chat-assistant/CompactAssistantInput.tsx
+++ b/features/agents/components/agent-widgets/chat-assistant/CompactAssistantInput.tsx
@@ -68,7 +68,9 @@ export function CompactAssistantInput({
   );
   const hasVariables = variableDefs.length > 0;
 
-  const isSendDisabled = isExecuting || !inputText.trim();
+  // Agents can execute on variables alone — text is NOT required.
+  // Only block when already executing (matches SmartAgentInput behavior).
+  const isSendDisabled = isExecuting;
 
   // ── Voice input ─────────────────────────────────────────────────────────────
   const {

--- a/features/agents/components/agent-widgets/chat-assistant/CompactAssistantInput.tsx
+++ b/features/agents/components/agent-widgets/chat-assistant/CompactAssistantInput.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { useState } from "react";
+/**
+ * CompactAssistantInput
+ *
+ * Compact message input for the chat assistant widget. Includes all the essential
+ * controls from SmartAgentInput (voice, resources, variable toggle, submit-on-enter)
+ * in a space-efficient layout.
+ *
+ * The textarea auto-resizes and supports Shift+Enter for newlines.
+ * All execution logic is driven by Redux — no prop drilling.
+ */
+
+import { useState, useRef, useEffect, useCallback } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/redux/hooks";
 import { setUserInputText } from "@/features/agents/redux/execution-system/instance-user-input/instance-user-input.slice";
 import { selectUserInputText } from "@/features/agents/redux/execution-system/instance-user-input/instance-user-input.selectors";
@@ -8,110 +19,264 @@ import {
   selectIsExecuting,
   selectConversationMode,
 } from "@/features/agents/redux/execution-system/selectors/aggregate.selectors";
+import { selectSubmitOnEnter } from "@/features/agents/redux/execution-system/instance-ui-state/instance-ui-state.selectors";
+import {
+  setSubmitOnEnter,
+  toggleVariablePanel,
+} from "@/features/agents/redux/execution-system/instance-ui-state/instance-ui-state.slice";
+import { selectInstanceVariableDefinitions } from "@/features/agents/redux/execution-system/instance-variable-values/instance-variable-values.selectors";
 import { executeInstance } from "@/features/agents/redux/execution-system/thunks/execute-instance.thunk";
 import { executeChatInstance } from "@/features/agents/redux/execution-system/thunks/execute-chat-instance.thunk";
 import { Button } from "@/components/ui/button";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { ArrowUp, Mic, Paperclip, Settings2 } from "lucide-react";
+  ArrowUp,
+  Mic,
+  Braces,
+  CornerDownLeft,
+} from "lucide-react";
+
+// Voice input
+import { useRecordAndTranscribe } from "@/features/audio";
+import { TranscriptionLoader } from "@/features/audio";
+
+// Resource picker
+import { SmartAgentResourcePickerButton } from "../../inputs/SmartAgentResourcePickerButton";
+import { SmartAgentResourceChips } from "../../inputs/SmartAgentResourceChips";
+
+import { toast } from "sonner";
 
 interface CompactAssistantInputProps {
   conversationId: string;
-  onToggleVariables?: () => void;
 }
 
 export function CompactAssistantInput({
   conversationId,
-  onToggleVariables,
 }: CompactAssistantInputProps) {
   const dispatch = useAppDispatch();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const pendingVoiceSubmitRef = useRef(false);
+
+  // ── Redux state ─────────────────────────────────────────────────────────────
   const inputText = useAppSelector(selectUserInputText(conversationId));
   const isExecuting = useAppSelector(selectIsExecuting(conversationId));
-  const conversationMode = useAppSelector(selectConversationMode(conversationId));
-  const [popoverOpen, setPopoverOpen] = useState(false);
+  const conversationMode = useAppSelector(
+    selectConversationMode(conversationId),
+  );
+  const submitOnEnter = useAppSelector(selectSubmitOnEnter(conversationId));
+  const variableDefs = useAppSelector(
+    selectInstanceVariableDefinitions(conversationId),
+  );
+  const hasVariables = variableDefs.length > 0;
 
   const isSendDisabled = isExecuting || !inputText.trim();
 
-  const handleSend = () => {
+  // ── Voice input ─────────────────────────────────────────────────────────────
+  const {
+    isRecording,
+    isTranscribing,
+    duration,
+    startRecording,
+    stopRecording,
+  } = useRecordAndTranscribe({
+    onTranscriptionComplete: (result) => {
+      if (result.success && result.text) {
+        const newText = inputText
+          ? `${inputText}\n${result.text}`
+          : result.text;
+        pendingVoiceSubmitRef.current = true;
+        dispatch(setUserInputText({ conversationId, text: newText }));
+      }
+    },
+    onError: (error) => {
+      toast.error("Transcription failed", { description: error });
+    },
+    autoTranscribe: true,
+  });
+
+  // Auto-submit after voice transcription
+  useEffect(() => {
+    if (pendingVoiceSubmitRef.current && inputText.trim()) {
+      pendingVoiceSubmitRef.current = false;
+      setTimeout(() => handleSend(), 50);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputText]);
+
+  // ── Auto-resize textarea ────────────────────────────────────────────────────
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 100)}px`;
+  }, [inputText]);
+
+  // ── Send logic ──────────────────────────────────────────────────────────────
+  const handleSend = useCallback(() => {
     if (isSendDisabled) return;
     if (conversationMode === "chat") {
-      dispatch(executeChatInstance({ conversationId: conversationId }));
+      dispatch(executeChatInstance({ conversationId }));
     } else {
       dispatch(executeInstance({ conversationId }));
     }
-  };
+  }, [isSendDisabled, conversationMode, conversationId, dispatch]);
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
-  };
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey && submitOnEnter) {
+        e.preventDefault();
+        if (!isSendDisabled) handleSend();
+      }
+    },
+    [submitOnEnter, isSendDisabled, handleSend],
+  );
+
+  const handleMicClick = useCallback(() => {
+    if (isRecording) stopRecording();
+    else if (!isTranscribing) startRecording();
+  }, [isRecording, isTranscribing, startRecording, stopRecording]);
 
   return (
-    <div className="flex items-center gap-1.5 px-2 py-1.5 border-t border-border bg-card">
-      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7 shrink-0 text-muted-foreground"
-          >
-            <Paperclip className="w-3.5 h-3.5" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent side="top" align="start" className="w-36 p-1.5">
-          <div className="space-y-0.5">
-            <button
-              className="w-full flex items-center gap-2 px-2 py-1.5 text-xs text-foreground rounded-md hover:bg-muted transition-colors"
-              onClick={() => setPopoverOpen(false)}
-            >
-              <Mic className="w-3.5 h-3.5 text-muted-foreground" />
-              Voice
-            </button>
-            {onToggleVariables && (
+    <div className="shrink-0 border-t border-border/40 bg-muted/10">
+      {/* Resource chips */}
+      <SmartAgentResourceChips conversationId={conversationId} />
+
+      {/* Textarea */}
+      <div className="px-2 pt-1">
+        <textarea
+          ref={textareaRef}
+          value={inputText}
+          onChange={(e) =>
+            dispatch(
+              setUserInputText({ conversationId, text: e.target.value }),
+            )
+          }
+          onKeyDown={handleKeyDown}
+          placeholder="Ask anything..."
+          disabled={isExecuting}
+          className="w-full bg-transparent border-none outline-none text-xs text-foreground placeholder:text-muted-foreground/50 resize-none overflow-y-auto scrollbar-hide disabled:opacity-60"
+          style={{ minHeight: 20, maxHeight: 100, fontSize: "16px" }}
+          rows={1}
+        />
+      </div>
+
+      {/* Toolbar — controls + send */}
+      <div className="flex items-center justify-between px-1.5 pb-1.5">
+        {/* Left: functional controls */}
+        <div className="flex items-center gap-0">
+          {isTranscribing && !isRecording ? (
+            <div className="px-1">
+              <TranscriptionLoader
+                message="Transcribing"
+                duration={duration}
+                size="sm"
+              />
+            </div>
+          ) : isRecording ? (
+            <div className="flex items-center gap-1 bg-blue-50 dark:bg-blue-900/20 rounded px-1.5 py-0.5 animate-pulse">
+              <div className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" />
+              <span className="text-[10px] font-medium text-blue-700 dark:text-blue-300">
+                {Math.floor(duration / 60)}:
+                {String(duration % 60).padStart(2, "0")}
+              </span>
               <button
-                className="w-full flex items-center gap-2 px-2 py-1.5 text-xs text-foreground rounded-md hover:bg-muted transition-colors"
-                onClick={() => {
-                  onToggleVariables();
-                  setPopoverOpen(false);
-                }}
+                onClick={stopRecording}
+                className="text-[10px] text-blue-600 hover:text-blue-700 font-medium"
               >
-                <Settings2 className="w-3.5 h-3.5 text-muted-foreground" />
-                Variables
+                Stop
               </button>
+            </div>
+          ) : (
+            <>
+              {/* Variable toggle */}
+              {hasVariables && (
+                <ToolbarButton
+                  icon={Braces}
+                  tooltip="Toggle variables"
+                  onClick={() =>
+                    dispatch(toggleVariablePanel(conversationId))
+                  }
+                />
+              )}
+
+              {/* Voice input */}
+              <ToolbarButton
+                icon={Mic}
+                tooltip="Record voice"
+                onClick={handleMicClick}
+              />
+
+              {/* Resource picker */}
+              <SmartAgentResourcePickerButton
+                conversationId={conversationId}
+              />
+            </>
+          )}
+        </div>
+
+        {/* Right: toggles + send */}
+        <div className="flex items-center gap-0">
+          {/* Submit on Enter toggle */}
+          <ToolbarButton
+            icon={CornerDownLeft}
+            tooltip={
+              submitOnEnter
+                ? "Enter submits (click to disable)"
+                : "Enter adds newline (click to enable)"
+            }
+            onClick={() =>
+              dispatch(
+                setSubmitOnEnter({ conversationId, value: !submitOnEnter }),
+              )
+            }
+            active={submitOnEnter}
+          />
+
+          {/* Send button */}
+          <Button
+            size="icon"
+            className="w-6 h-6 rounded-full bg-primary text-primary-foreground shrink-0 disabled:opacity-40 ml-0.5"
+            disabled={isSendDisabled}
+            onClick={handleSend}
+          >
+            {isExecuting ? (
+              <div className="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+            ) : (
+              <ArrowUp className="w-3 h-3" />
             )}
-          </div>
-        </PopoverContent>
-      </Popover>
-
-      <input
-        type="text"
-        className="flex-1 h-7 bg-transparent text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none min-w-0"
-        style={{ fontSize: "16px" }}
-        placeholder="Ask anything..."
-        value={inputText}
-        onChange={(e) =>
-          dispatch(setUserInputText({ conversationId: conversationId, text: e.target.value }))
-        }
-        onKeyDown={handleKeyDown}
-      />
-
-      <Button
-        size="icon"
-        className="w-7 h-7 rounded-full bg-primary text-primary-foreground shrink-0 disabled:opacity-40"
-        disabled={isSendDisabled}
-        onClick={handleSend}
-      >
-        {isExecuting ? (
-          <div className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
-        ) : (
-          <ArrowUp className="w-3.5 h-3.5" />
-        )}
-      </Button>
+          </Button>
+        </div>
+      </div>
     </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Toolbar button helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ToolbarButton({
+  icon: Icon,
+  tooltip,
+  onClick,
+  active = false,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  tooltip: string;
+  onClick: () => void;
+  active?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={tooltip}
+      className={`h-6 w-6 flex items-center justify-center rounded-md transition-colors ${
+        active
+          ? "text-primary bg-primary/10"
+          : "text-muted-foreground hover:text-foreground hover:bg-muted"
+      }`}
+    >
+      <Icon className="w-3 h-3" />
+    </button>
   );
 }

--- a/features/agents/components/agent-widgets/chat-assistant/index.ts
+++ b/features/agents/components/agent-widgets/chat-assistant/index.ts
@@ -4,6 +4,7 @@ export { AssistantMessageCard } from "./AssistantMessageCard";
 export { UserMessageCard } from "./UserMessageCard";
 export { StatusCard } from "./StatusCard";
 export { VariableInputCard } from "./VariableInputCard";
+export { ChatAssistantVariableInputs } from "./ChatAssistantVariableInputs";
 export { CompactAssistantInput } from "./CompactAssistantInput";
 export { AssistantControlBar } from "./AssistantControlBar";
 export { useAssistantHeartbeat } from "./useAssistantHeartbeat";


### PR DESCRIPTION
The chat-assistant widget was non-functional because it used simplified
message card components that lacked the full rendering pipeline and did
not render variable input components at all.

Key changes:
- AssistantCardStack now uses real AgentAssistantMessage (with full
  MarkdownStream/artifact support) and AgentUserMessage instead of
  simplified card stubs, following the unified displayMessages pattern
  from AgentConversationDisplay for correct streaming behavior
- New ChatAssistantVariableInputs component renders all agent variables
  in a collapsible, compact row layout regardless of conversation state
- AgentChatAssistant container redesigned: wider panel (w-80), transparent
  backdrop-blur chrome, no bordered card around messages
- CompactAssistantInput upgraded with voice input, resource picker,
  variable toggle, submit-on-enter toggle, and auto-resizing textarea

https://claude.ai/code/session_01AKNBvn5tw6bZAThtpW9vdc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/UX refactor that changes streaming message composition and execution triggers (voice auto-submit, variables-only runs), which could affect chat execution flow and state handling. No authentication or sensitive data-path changes.
> 
> **Overview**
> Reworks the chat-assistant widget to render conversation output using the real `AgentUserMessage`/`AgentAssistantMessage` pipeline (dynamic import, unified `displayMessages` history+live stream) so streaming messages and artifacts behave correctly, including status/info/error handling and auto-scroll.
> 
> Adds a new collapsible `ChatAssistantVariableInputs` panel (toggleable via Redux and shown before the first message) and updates the input bar to include voice recording/transcription with optional auto-submit, resource chips/picker, variable panel toggle, submit-on-enter toggle, and an auto-resizing textarea. The floating widget container is also restyled (wider, transparent/backdrop-blur chrome, draggable header).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07c71ed77d542f3315852c88cdfe1606291ac33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->