### PR TITLE
Two-tier sandboxes + rich orchestrator API consumption

### DIFF
--- a/app/(authenticated)/(admin-auth)/administration/categories.tsx
+++ b/app/(authenticated)/(admin-auth)/administration/categories.tsx
@@ -130,6 +130,14 @@ export const adminCategories = [
     iconColor: "text-orange-600",
     features: [
       {
+        title: "Sandbox Infrastructure",
+        description:
+          "Live health for the EC2 + self-hosted orchestrators backing /code: per-tier disk/memory/CPU pressure, container counts, latest deploy runs, and one-click trigger. Catches silent deploy failures early.",
+        icon: <IconDashboard />,
+        link: "/administration/sandbox-infra",
+        isNew: true,
+      },
+      {
         title: "Sandbox Management",
         description:
           "Monitor all sandbox instances, manage containers, and access running sandboxes via SSH",

--- a/app/(authenticated)/(admin-auth)/administration/sandbox-infra/page.tsx
+++ b/app/(authenticated)/(admin-auth)/administration/sandbox-infra/page.tsx
@@ -1,0 +1,522 @@
+"use client";
+
+/**
+ * Sandbox Infrastructure admin panel.
+ *
+ * Single pane of glass for the EC2 + hosted orchestrators that back the
+ * /code editor's sandbox feature. Surfaces the silent-failure modes that
+ * bit us on 2026-04-26 (disk-full → deploy fails → orchestrator stays on
+ * stale code for 73 days):
+ *
+ *   - Per-tier health + version + route count (catches stale deploys).
+ *   - Disk pressure with red threshold at 80% (catches disk-full early).
+ *   - Latest GHA deploy runs (catches silently-failing deploys).
+ *   - One-click "trigger deploy" (recover without leaving the browser).
+ *
+ * Backed by:
+ *   - GET  /api/sandbox/system           → both tiers' /system payloads
+ *   - GET  /api/sandbox/deploy           → recent matrx-sandbox GHA runs
+ *   - POST /api/sandbox/deploy           → workflow_dispatch the deploy
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import {
+    Activity,
+    AlertCircle,
+    Box,
+    CheckCircle2,
+    CircleAlert,
+    Clock,
+    Cpu,
+    ExternalLink,
+    HardDrive,
+    History,
+    Loader2,
+    MemoryStick,
+    PlayCircle,
+    RefreshCw,
+    Server,
+    XCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface OrchestratorSystem {
+    tier: "ec2" | "hosted" | null;
+    uptime_seconds: number;
+    disk_total_bytes: number;
+    disk_used_bytes: number;
+    disk_free_bytes: number;
+    disk_used_pct: number;
+    memory_total_kb: number;
+    memory_used_kb: number;
+    memory_available_kb: number;
+    memory_used_pct: number;
+    cpu_count: number;
+    load_1m: number | null;
+    load_5m: number | null;
+    load_15m: number | null;
+    sandboxes_in_db: number;
+    sandboxes_active: number;
+    sandbox_containers_total: number;
+    sandbox_containers_running: number;
+}
+
+interface TierStatus {
+    tier: "ec2" | "hosted";
+    url: string;
+    ok: boolean;
+    status: "healthy" | "unreachable" | "error";
+    error?: string;
+    system?: OrchestratorSystem;
+    info?: { version?: string; tier?: string };
+    routeCount?: number;
+    fetchedAt: string;
+}
+
+interface DeployRun {
+    id: number;
+    run_number: number;
+    status: string; // "queued" | "in_progress" | "completed"
+    conclusion: string | null; // "success" | "failure" | "cancelled" | null while running
+    head_branch: string;
+    head_sha: string;
+    event: string;
+    display_title: string;
+    actor: string | null;
+    created_at: string;
+    updated_at: string;
+    run_started_at: string;
+    html_url: string;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function bytesHuman(bytes: number): string {
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    let n = bytes;
+    let i = 0;
+    while (n >= 1024 && i < units.length - 1) {
+        n /= 1024;
+        i++;
+    }
+    return `${n.toFixed(n < 10 ? 1 : 0)} ${units[i]}`;
+}
+
+function uptimeHuman(seconds: number): string {
+    if (seconds < 60) return `${seconds.toFixed(0)}s`;
+    if (seconds < 3600) return `${(seconds / 60).toFixed(0)}m`;
+    if (seconds < 86400) return `${(seconds / 3600).toFixed(1)}h`;
+    return `${(seconds / 86400).toFixed(1)}d`;
+}
+
+function relativeTime(iso: string): string {
+    const ms = Date.now() - new Date(iso).getTime();
+    if (ms < 60_000) return `${Math.round(ms / 1000)}s ago`;
+    if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
+    if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h ago`;
+    return `${Math.round(ms / 86_400_000)}d ago`;
+}
+
+function pctClass(pct: number): string {
+    if (pct >= 90) return "text-destructive";
+    if (pct >= 80) return "text-orange-500 dark:text-orange-400";
+    if (pct >= 60) return "text-yellow-600 dark:text-yellow-400";
+    return "text-emerald-600 dark:text-emerald-400";
+}
+
+function pctBarBg(pct: number): string {
+    if (pct >= 90) return "bg-destructive";
+    if (pct >= 80) return "bg-orange-500";
+    if (pct >= 60) return "bg-yellow-500";
+    return "bg-emerald-500";
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+function PressureBar({ label, pct, hint }: { label: string; pct: number; hint?: string }) {
+    return (
+        <div>
+            <div className="flex items-baseline justify-between text-xs">
+                <span className="text-muted-foreground">{label}</span>
+                <span className={`font-mono ${pctClass(pct)}`}>{pct.toFixed(1)}%</span>
+            </div>
+            <div className="mt-1 h-1.5 w-full bg-muted rounded overflow-hidden">
+                <div
+                    className={`h-full transition-all ${pctBarBg(pct)}`}
+                    style={{ width: `${Math.min(pct, 100)}%` }}
+                />
+            </div>
+            {hint && <div className="mt-1 text-xs text-muted-foreground font-mono">{hint}</div>}
+        </div>
+    );
+}
+
+function StatRow({ label, value, hint }: { label: string; value: React.ReactNode; hint?: string }) {
+    return (
+        <div className="flex items-baseline justify-between gap-4 text-sm">
+            <span className="text-muted-foreground">{label}</span>
+            <span className="font-mono text-foreground text-right">
+                {value}
+                {hint && <span className="text-muted-foreground ml-1.5">{hint}</span>}
+            </span>
+        </div>
+    );
+}
+
+function TierCard({ tier }: { tier: TierStatus }) {
+    const sys = tier.system;
+    const tierLabel = tier.tier === "ec2" ? "EC2" : "Hosted";
+
+    return (
+        <div className="rounded-lg border border-border bg-card p-4 flex flex-col gap-3">
+            <div className="flex items-start justify-between gap-2">
+                <div>
+                    <div className="flex items-center gap-2">
+                        <Server className="w-4 h-4 text-muted-foreground" />
+                        <h3 className="text-base font-semibold">{tierLabel} tier</h3>
+                        {tier.ok ? (
+                            <Badge variant="outline" className="text-emerald-600 border-emerald-600/40 dark:text-emerald-400 dark:border-emerald-400/40">
+                                <CheckCircle2 className="w-3 h-3 mr-1" /> healthy
+                            </Badge>
+                        ) : (
+                            <Badge variant="destructive">
+                                <XCircle className="w-3 h-3 mr-1" /> {tier.status}
+                            </Badge>
+                        )}
+                    </div>
+                    <a
+                        href={tier.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-muted-foreground hover:text-primary inline-flex items-center gap-1 mt-1"
+                    >
+                        {tier.url} <ExternalLink className="w-3 h-3" />
+                    </a>
+                </div>
+                <div className="text-right">
+                    <div className="text-xs text-muted-foreground">version</div>
+                    <div className="text-sm font-mono">
+                        {tier.info?.version ?? <span className="text-muted-foreground">—</span>}
+                    </div>
+                </div>
+            </div>
+
+            {!tier.ok && tier.error && (
+                <div className="rounded border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive">
+                    <AlertCircle className="w-3 h-3 inline mr-1" />
+                    {tier.error}
+                </div>
+            )}
+
+            {sys && (
+                <>
+                    <div className="grid gap-2.5">
+                        <PressureBar
+                            label="Disk"
+                            pct={sys.disk_used_pct}
+                            hint={`${bytesHuman(sys.disk_used_bytes)} / ${bytesHuman(sys.disk_total_bytes)}  ·  ${bytesHuman(sys.disk_free_bytes)} free`}
+                        />
+                        <PressureBar
+                            label="Memory"
+                            pct={sys.memory_used_pct}
+                            hint={`${bytesHuman(sys.memory_used_kb * 1024)} / ${bytesHuman(sys.memory_total_kb * 1024)}`}
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 pt-2 border-t border-border">
+                        <StatRow label="CPU" value={`${sys.cpu_count}`} hint="cores" />
+                        <StatRow
+                            label="Load"
+                            value={
+                                sys.load_1m !== null
+                                    ? `${sys.load_1m.toFixed(2)} ${sys.load_5m?.toFixed(2) ?? "—"} ${sys.load_15m?.toFixed(2) ?? "—"}`
+                                    : "—"
+                            }
+                        />
+                        <StatRow label="Uptime" value={uptimeHuman(sys.uptime_seconds)} />
+                        <StatRow label="Routes" value={tier.routeCount ?? "—"} />
+                        <StatRow label="Sandboxes (DB)" value={`${sys.sandboxes_active} / ${sys.sandboxes_in_db}`} hint="active / total" />
+                        <StatRow
+                            label="Containers"
+                            value={`${sys.sandbox_containers_running} / ${sys.sandbox_containers_total}`}
+                            hint="running / total"
+                        />
+                    </div>
+
+                    {sys.sandboxes_active !== sys.sandbox_containers_running && (
+                        <div className="rounded border border-yellow-500/30 bg-yellow-500/5 p-2 text-xs text-yellow-700 dark:text-yellow-400">
+                            <CircleAlert className="w-3 h-3 inline mr-1" />
+                            DB shows {sys.sandboxes_active} active sandboxes but Docker has {sys.sandbox_containers_running} running. State drift — investigate.
+                        </div>
+                    )}
+                </>
+            )}
+
+            <div className="text-xs text-muted-foreground pt-1">
+                Fetched {relativeTime(tier.fetchedAt)}
+            </div>
+        </div>
+    );
+}
+
+function DeployRunRow({ run }: { run: DeployRun }) {
+    const isRunning = run.status !== "completed";
+    const success = run.conclusion === "success";
+    const failure = run.conclusion === "failure" || run.conclusion === "cancelled";
+
+    return (
+        <a
+            href={run.html_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-between gap-3 px-3 py-2 hover:bg-muted/50 rounded text-sm border-b border-border last:border-b-0"
+        >
+            <div className="flex items-center gap-3 min-w-0">
+                {isRunning ? (
+                    <Loader2 className="w-4 h-4 text-primary animate-spin shrink-0" />
+                ) : success ? (
+                    <CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0" />
+                ) : failure ? (
+                    <XCircle className="w-4 h-4 text-destructive shrink-0" />
+                ) : (
+                    <Activity className="w-4 h-4 text-muted-foreground shrink-0" />
+                )}
+                <div className="min-w-0">
+                    <div className="truncate text-foreground">{run.display_title}</div>
+                    <div className="text-xs text-muted-foreground font-mono truncate">
+                        #{run.run_number} · {run.event} · {run.head_branch}@{run.head_sha.slice(0, 7)}
+                        {run.actor && ` · ${run.actor}`}
+                    </div>
+                </div>
+            </div>
+            <div className="text-xs text-muted-foreground shrink-0 text-right">
+                <div>{relativeTime(run.run_started_at || run.created_at)}</div>
+                <div className="font-mono">{run.conclusion ?? run.status}</div>
+            </div>
+        </a>
+    );
+}
+
+// ─── Page ───────────────────────────────────────────────────────────────────
+
+export default function SandboxInfraPage() {
+    const [tiers, setTiers] = useState<TierStatus[]>([]);
+    const [tiersLoading, setTiersLoading] = useState(true);
+    const [tiersError, setTiersError] = useState<string | null>(null);
+    const [runs, setRuns] = useState<DeployRun[]>([]);
+    const [runsLoading, setRunsLoading] = useState(true);
+    const [runsError, setRunsError] = useState<string | null>(null);
+    const [deployTokenAttached, setDeployTokenAttached] = useState(false);
+    const [dispatching, setDispatching] = useState(false);
+
+    const refreshTiers = useCallback(async () => {
+        setTiersLoading(true);
+        setTiersError(null);
+        try {
+            const resp = await fetch("/api/sandbox/system");
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const data = await resp.json();
+            setTiers(data.tiers ?? []);
+        } catch (err) {
+            setTiersError(err instanceof Error ? err.message : "unknown error");
+        } finally {
+            setTiersLoading(false);
+        }
+    }, []);
+
+    const refreshRuns = useCallback(async () => {
+        setRunsLoading(true);
+        setRunsError(null);
+        try {
+            const resp = await fetch("/api/sandbox/deploy");
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const data = await resp.json();
+            setRuns(data.runs ?? []);
+            setDeployTokenAttached(!!data.tokenAttached);
+        } catch (err) {
+            setRunsError(err instanceof Error ? err.message : "unknown error");
+        } finally {
+            setRunsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void refreshTiers();
+        void refreshRuns();
+        // Poll every 30s — orchestrator state changes slowly, no need to hammer.
+        const interval = setInterval(() => {
+            void refreshTiers();
+            void refreshRuns();
+        }, 30_000);
+        return () => clearInterval(interval);
+    }, [refreshTiers, refreshRuns]);
+
+    const triggerDeploy = useCallback(async () => {
+        if (!confirm("Trigger a fresh matrx-sandbox deploy via GitHub Actions?")) return;
+        setDispatching(true);
+        try {
+            const resp = await fetch("/api/sandbox/deploy", { method: "POST" });
+            const data = await resp.json();
+            if (!resp.ok) {
+                toast.error(data.error || "Failed to trigger deploy", {
+                    description: data.details,
+                });
+            } else {
+                toast.success("Deploy queued", {
+                    description: data.note ?? "Refreshing in 5s",
+                });
+                setTimeout(() => void refreshRuns(), 5000);
+            }
+        } catch (err) {
+            toast.error("Network error", {
+                description: err instanceof Error ? err.message : String(err),
+            });
+        } finally {
+            setDispatching(false);
+        }
+    }, [refreshRuns]);
+
+    return (
+        <div className="h-[calc(100vh-2.5rem)] flex flex-col overflow-hidden bg-textured">
+            <div className="px-6 py-4 border-b border-border flex items-center justify-between">
+                <div>
+                    <h1 className="text-xl font-semibold">Sandbox Infrastructure</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Live health for the EC2 and self-hosted sandbox orchestrators. Auto-refreshes every 30s.
+                    </p>
+                </div>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                        void refreshTiers();
+                        void refreshRuns();
+                    }}
+                    disabled={tiersLoading || runsLoading}
+                >
+                    <RefreshCw className={`w-4 h-4 mr-2 ${tiersLoading || runsLoading ? "animate-spin" : ""}`} />
+                    Refresh
+                </Button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-6">
+                {/* Tier health cards */}
+                <section>
+                    <h2 className="text-sm font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+                        <Activity className="w-4 h-4" />
+                        Orchestrator health
+                    </h2>
+                    {tiersError && (
+                        <div className="rounded border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                            <AlertCircle className="w-4 h-4 inline mr-1" />
+                            Couldn&apos;t load tier status: {tiersError}
+                        </div>
+                    )}
+                    {tiersLoading && tiers.length === 0 && (
+                        <div className="text-sm text-muted-foreground flex items-center gap-2">
+                            <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+                        </div>
+                    )}
+                    <div className="grid gap-3 md:grid-cols-2">
+                        {tiers.map((t) => (
+                            <TierCard key={t.tier} tier={t} />
+                        ))}
+                    </div>
+                </section>
+
+                {/* Recent GHA deploys */}
+                <section>
+                    <div className="flex items-center justify-between mb-2">
+                        <h2 className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+                            <History className="w-4 h-4" />
+                            Recent matrx-sandbox deploys
+                        </h2>
+                        <Button
+                            variant="default"
+                            size="sm"
+                            onClick={triggerDeploy}
+                            disabled={dispatching || !deployTokenAttached}
+                            title={!deployTokenAttached ? "Set MATRX_SANDBOX_GH_TOKEN env var to enable" : ""}
+                        >
+                            {dispatching ? (
+                                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                            ) : (
+                                <PlayCircle className="w-4 h-4 mr-2" />
+                            )}
+                            Trigger deploy
+                        </Button>
+                    </div>
+                    {!deployTokenAttached && (
+                        <div className="rounded border border-yellow-500/30 bg-yellow-500/5 p-2 text-xs text-yellow-700 dark:text-yellow-400 mb-2">
+                            <CircleAlert className="w-3 h-3 inline mr-1" />
+                            <code className="font-mono">MATRX_SANDBOX_GH_TOKEN</code> not set on the Vercel server. Read works (rate-limited);
+                            triggering deploys is disabled.
+                        </div>
+                    )}
+                    {runsError && (
+                        <div className="rounded border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                            <AlertCircle className="w-4 h-4 inline mr-1" />
+                            Couldn&apos;t load deploy runs: {runsError}
+                        </div>
+                    )}
+                    <div className="rounded-lg border border-border bg-card overflow-hidden">
+                        {runsLoading && runs.length === 0 && (
+                            <div className="px-3 py-4 text-sm text-muted-foreground flex items-center gap-2">
+                                <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+                            </div>
+                        )}
+                        {!runsLoading && runs.length === 0 && !runsError && (
+                            <div className="px-3 py-4 text-sm text-muted-foreground">No recent runs.</div>
+                        )}
+                        {runs.map((run) => (
+                            <DeployRunRow key={run.id} run={run} />
+                        ))}
+                    </div>
+                </section>
+
+                {/* Glossary so non-experts can read the panel */}
+                <section className="text-xs text-muted-foreground border-t border-border pt-3">
+                    <div className="grid gap-1.5 md:grid-cols-2">
+                        <p>
+                            <span className="font-medium text-foreground inline-flex items-center gap-1">
+                                <HardDrive className="w-3 h-3" /> Disk pressure
+                            </span>
+                            : red &gt;90% means deploys are about to fail. Run <code className="font-mono">docker system prune -af</code> on the host (the
+                            new deploy pipeline does this automatically every push).
+                        </p>
+                        <p>
+                            <span className="font-medium text-foreground inline-flex items-center gap-1">
+                                <MemoryStick className="w-3 h-3" /> Memory pressure
+                            </span>
+                            : 80%+ on a tier means it&apos;s near capacity for new sandboxes. Each sandbox uses ~4 GB by default.
+                        </p>
+                        <p>
+                            <span className="font-medium text-foreground inline-flex items-center gap-1">
+                                <Cpu className="w-3 h-3" /> Load
+                            </span>
+                            : 1m / 5m / 15m averages from <code className="font-mono">/proc/loadavg</code>. Sustained &gt;CPU-count = overloaded.
+                        </p>
+                        <p>
+                            <span className="font-medium text-foreground inline-flex items-center gap-1">
+                                <Box className="w-3 h-3" /> DB vs Containers drift
+                            </span>
+                            : when DB shows more active sandboxes than Docker has running, an orchestrator restart lost track. Reconcile via the orchestrator
+                            store&apos;s <code className="font-mono">reconcile()</code>.
+                        </p>
+                        <p>
+                            <span className="font-medium text-foreground inline-flex items-center gap-1">
+                                <Clock className="w-3 h-3" /> Stale deploy
+                            </span>
+                            : if the orchestrator&apos;s version differs from the latest <code className="font-mono">main</code> tag in matrx-sandbox, the
+                            deploy didn&apos;t take effect. Check the latest GHA run for the failure.
+                        </p>
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/app/api/sandbox/[id]/access/route.ts
+++ b/app/api/sandbox/[id]/access/route.ts
@@ -1,52 +1,42 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/utils/supabase/server'
+import {
+    lookupSandboxAndOrchestrator,
+    orchestratorJsonHeaders,
+} from '@/lib/sandbox/orchestrator-routing'
 
-const ORCHESTRATOR_URL = process.env.MATRX_ORCHESTRATOR_URL || 'http://54.144.86.132:8000'
-const ORCHESTRATOR_API_KEY = process.env.MATRX_ORCHESTRATOR_API_KEY || ''
-
+/**
+ * POST /api/sandbox/[id]/access
+ *
+ * Generates a one-time Ed25519 keypair, injects the public half into the
+ * container, and returns the private half for direct human SSH. The orchestrator
+ * never stores the private key.
+ *
+ * Tier-aware: routes to the correct orchestrator based on the sandbox row's
+ * config.tier.
+ */
 export async function POST(
-    request: NextRequest,
+    _request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params
-        const supabase = await createClient()
-        const {
-            data: { user },
-            error: userError,
-        } = await supabase.auth.getUser()
 
-        if (userError || !user) {
-            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
+        const lookup = await lookupSandboxAndOrchestrator(id)
+        if (!lookup.ok) {
+            return NextResponse.json({ error: lookup.error }, { status: lookup.status })
         }
 
-        const { data: instance, error: fetchError } = await supabase
-            .from('sandbox_instances')
-            .select('sandbox_id, status')
-            .eq('id', id)
-            .eq('user_id', user.id)
-            .single()
-
-        if (fetchError || !instance) {
-            return NextResponse.json({ error: 'Sandbox instance not found' }, { status: 404 })
-        }
-
-        if (!['ready', 'running'].includes(instance.status)) {
+        if (!['ready', 'running'].includes(lookup.status)) {
             return NextResponse.json(
-                { error: `Sandbox is not running (status: ${instance.status})` },
+                { error: `Sandbox is not running (status: ${lookup.status})` },
                 { status: 409 }
             )
         }
 
-        const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-        if (ORCHESTRATOR_API_KEY) {
-            headers['X-API-Key'] = ORCHESTRATOR_API_KEY
-        }
-
         try {
             const resp = await fetch(
-                `${ORCHESTRATOR_URL}/sandboxes/${instance.sandbox_id}/access`,
-                { method: 'POST', headers }
+                `${lookup.orchestrator.url}/sandboxes/${lookup.sandboxId}/access`,
+                { method: 'POST', headers: orchestratorJsonHeaders(lookup.orchestrator) }
             )
 
             if (!resp.ok) {
@@ -63,7 +53,7 @@ export async function POST(
         } catch (fetchError) {
             console.error('Orchestrator connection failed:', fetchError)
             return NextResponse.json(
-                { error: 'Sandbox orchestrator is not reachable. Ensure the orchestrator service is running.' },
+                { error: 'Sandbox orchestrator is not reachable' },
                 { status: 502 }
             )
         }

--- a/app/api/sandbox/[id]/credentials/revoke/route.ts
+++ b/app/api/sandbox/[id]/credentials/revoke/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * POST /api/sandbox/[id]/credentials/revoke
+ *
+ * Removes the git credential helper script and unsets the git config the
+ * matching POST /credentials installed. Use on logout / disconnect.
+ */
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const { id } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/credentials/revoke`
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { timeoutMs: 30_000 })
+}

--- a/app/api/sandbox/[id]/credentials/route.ts
+++ b/app/api/sandbox/[id]/credentials/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * POST /api/sandbox/[id]/credentials
+ *
+ * Configures git/SSH credentials inside the sandbox. The orchestrator stores
+ * the secret in a mode-restricted helper script and wires `git config --global
+ * credential.helper` so subsequent `git push` works without the user pasting
+ * tokens into a terminal.
+ *
+ * Body shapes:
+ *   { kind: "github", token: "ghp_…", scope?: "read"|"write" }
+ *   { kind: "ssh",    private_key: "-----BEGIN…", known_hosts?: "…" }
+ *
+ * Tokens never appear in /fs/read listings; revoked on sandbox stop or via
+ * /api/sandbox/[id]/credentials/revoke.
+ */
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const { id } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/credentials`
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { timeoutMs: 30_000 })
+}

--- a/app/api/sandbox/[id]/exec/route.ts
+++ b/app/api/sandbox/[id]/exec/route.ts
@@ -1,45 +1,43 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/utils/supabase/server'
+import {
+    lookupSandboxAndOrchestrator,
+    orchestratorJsonHeaders,
+} from '@/lib/sandbox/orchestrator-routing'
 
-const ORCHESTRATOR_URL = process.env.MATRX_ORCHESTRATOR_URL || 'http://54.144.86.132:8000'
-const ORCHESTRATOR_API_KEY = process.env.MATRX_ORCHESTRATOR_API_KEY || ''
-
+/**
+ * POST /api/sandbox/[id]/exec
+ *
+ * Buffered exec — single JSON response at end-of-command. For long-running
+ * commands use POST /api/sandbox/[id]/exec/stream instead.
+ *
+ * Body:
+ *   { command: string, timeout?: number, cwd?: string,
+ *     env?: Record<string,string>, stdin?: string }
+ *
+ * Tier routing is automatic: the sandbox row's `config.tier` determines which
+ * orchestrator we forward to.
+ */
 export async function POST(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params
-        const supabase = await createClient()
-        const {
-            data: { user },
-            error: userError,
-        } = await supabase.auth.getUser()
 
-        if (userError || !user) {
-            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
+        const lookup = await lookupSandboxAndOrchestrator(id)
+        if (!lookup.ok) {
+            return NextResponse.json({ error: lookup.error }, { status: lookup.status })
         }
 
-        const { data: instance, error: fetchError } = await supabase
-            .from('sandbox_instances')
-            .select('sandbox_id, status')
-            .eq('id', id)
-            .eq('user_id', user.id)
-            .single()
-
-        if (fetchError || !instance) {
-            return NextResponse.json({ error: 'Sandbox instance not found' }, { status: 404 })
-        }
-
-        if (!['ready', 'running'].includes(instance.status)) {
+        if (!['ready', 'running'].includes(lookup.status)) {
             return NextResponse.json(
-                { error: `Sandbox is not running (status: ${instance.status})` },
+                { error: `Sandbox is not running (status: ${lookup.status})` },
                 { status: 409 }
             )
         }
 
         const body = await request.json()
-        const { command, timeout, cwd } = body
+        const { command, timeout, cwd, env, stdin } = body
 
         if (!command || typeof command !== 'string' || !command.trim()) {
             return NextResponse.json({ error: 'command is required' }, { status: 400 })
@@ -52,25 +50,20 @@ export async function POST(
             )
         }
 
-        const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-        if (ORCHESTRATOR_API_KEY) {
-            headers['X-API-Key'] = ORCHESTRATOR_API_KEY
-        }
-
         const execPayload: Record<string, unknown> = {
             command,
             timeout: Math.min(Math.max(timeout || 30, 1), 600),
         }
-        if (cwd && typeof cwd === 'string') {
-            execPayload.cwd = cwd
-        }
+        if (cwd && typeof cwd === 'string') execPayload.cwd = cwd
+        if (env && typeof env === 'object') execPayload.env = env
+        if (typeof stdin === 'string') execPayload.stdin = stdin
 
         try {
             const resp = await fetch(
-                `${ORCHESTRATOR_URL}/sandboxes/${instance.sandbox_id}/exec`,
+                `${lookup.orchestrator.url}/sandboxes/${lookup.sandboxId}/exec`,
                 {
                     method: 'POST',
-                    headers,
+                    headers: orchestratorJsonHeaders(lookup.orchestrator),
                     body: JSON.stringify(execPayload),
                 }
             )
@@ -89,7 +82,7 @@ export async function POST(
         } catch (fetchError) {
             console.error('Orchestrator connection failed:', fetchError)
             return NextResponse.json(
-                { error: 'Sandbox orchestrator is not reachable. Ensure the orchestrator service is running.' },
+                { error: 'Sandbox orchestrator is not reachable' },
                 { status: 502 }
             )
         }

--- a/app/api/sandbox/[id]/exec/stream/route.ts
+++ b/app/api/sandbox/[id]/exec/stream/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * POST /api/sandbox/[id]/exec/stream
+ *
+ * Streaming exec — returns text/event-stream chunks for incremental
+ * stdout/stderr instead of one buffered JSON blob at the end. Use for long
+ * commands (npm install, builds, test runs) so the UI shows progress and
+ * cancellation works (close the SSE = orchestrator cancels).
+ *
+ * Body shape mirrors the buffered /exec endpoint:
+ *   { command, cwd?, env?, stdin?, timeout? }
+ *
+ * Response: Content-Type: text/event-stream with `stdout` / `stderr` / `exit`
+ * events.
+ */
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const { id } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/exec/stream`
+    // No timeout — long builds (e.g. pnpm install on a fresh node_modules) can
+    // run for many minutes. Cancellation comes from the client closing the
+    // connection, which propagates through the proxy to the orchestrator.
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { stream: true })
+}

--- a/app/api/sandbox/[id]/extend/route.ts
+++ b/app/api/sandbox/[id]/extend/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import {
+    lookupSandboxAndOrchestrator,
+    orchestratorJsonHeaders,
+} from '@/lib/sandbox/orchestrator-routing'
+
+/**
+ * POST /api/sandbox/[id]/extend
+ *
+ * Extends a sandbox's TTL by calling the orchestrator's `/sandboxes/{id}/extend`
+ * endpoint, then mirrors the new `expires_at` into the local Postgres row so
+ * UI and the orchestrator stay in sync. This replaces the old DB-only "extend"
+ * action on PUT /api/sandbox/[id], which silently drifted from orchestrator
+ * state.
+ *
+ * Body:
+ *   { ttl_seconds?: number }   // default 3600, range 60..86400
+ */
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const { id } = await params
+
+        const lookup = await lookupSandboxAndOrchestrator(id)
+        if (!lookup.ok) {
+            return NextResponse.json({ error: lookup.error }, { status: lookup.status })
+        }
+
+        const body = await request.json().catch(() => ({}))
+        const ttlSeconds = Number(body?.ttl_seconds ?? 3600)
+        if (!Number.isFinite(ttlSeconds) || ttlSeconds < 60 || ttlSeconds > 86400) {
+            return NextResponse.json(
+                { error: 'ttl_seconds must be between 60 and 86400' },
+                { status: 400 }
+            )
+        }
+
+        // Forward to the orchestrator hosting this sandbox's tier.
+        let resp: Response
+        try {
+            resp = await fetch(
+                `${lookup.orchestrator.url}/sandboxes/${lookup.sandboxId}/extend`,
+                {
+                    method: 'POST',
+                    headers: orchestratorJsonHeaders(lookup.orchestrator),
+                    body: JSON.stringify({ ttl_seconds: ttlSeconds }),
+                }
+            )
+        } catch (fetchError) {
+            console.error('Orchestrator extend connection failed:', fetchError)
+            return NextResponse.json(
+                { error: 'Sandbox orchestrator is not reachable' },
+                { status: 502 }
+            )
+        }
+
+        if (!resp.ok) {
+            const errBody = await resp.text()
+            console.error('Orchestrator extend failed:', resp.status, errBody)
+            return NextResponse.json(
+                { error: 'Failed to extend sandbox', details: errBody },
+                { status: resp.status >= 500 ? 502 : resp.status }
+            )
+        }
+
+        const orchestratorPayload = await resp.json()
+        const newExpiresAt = orchestratorPayload?.new_expires_at || orchestratorPayload?.expires_at
+        if (!newExpiresAt) {
+            return NextResponse.json(
+                { error: 'Orchestrator extend returned no expires_at — likely on stale code' },
+                { status: 502 }
+            )
+        }
+
+        // Mirror the orchestrator's authoritative new expiry into our DB.
+        const supabase = await createClient()
+        const { data: instance, error: updateError } = await supabase
+            .from('sandbox_instances')
+            .update({
+                expires_at: newExpiresAt,
+                ttl_seconds: ttlSeconds,
+            })
+            .eq('id', id)
+            .select()
+            .single()
+
+        if (updateError) {
+            console.error('Failed to mirror extend into DB:', updateError)
+            // Don't fail the request — orchestrator already accepted the extend.
+            return NextResponse.json({
+                instance: null,
+                orchestrator: orchestratorPayload,
+                warning: 'Extended at orchestrator but local DB mirror failed',
+            })
+        }
+
+        return NextResponse.json({
+            instance,
+            orchestrator: orchestratorPayload,
+        })
+    } catch (error) {
+        console.error('Sandbox extend API error:', error)
+        return NextResponse.json(
+            {
+                error: 'Internal server error',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            },
+            { status: 500 }
+        )
+    }
+}

--- a/app/api/sandbox/[id]/fs/[...path]/route.ts
+++ b/app/api/sandbox/[id]/fs/[...path]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * Catchall proxy for the sandbox filesystem API.
+ *
+ * Routes every method (GET/POST/PUT/DELETE/PATCH) under
+ *   /api/sandbox/[id]/fs/...
+ * to the orchestrator at
+ *   {orchestrator}/sandboxes/{sandbox_id}/fs/...
+ *
+ * The orchestrator forwards into the in-container `matrx_agent` daemon which
+ * implements the actual fs operations (list/stat/read/write/patch/delete/
+ * mkdir/rename/copy/upload/download/batch). Binary content uses
+ * `?encoding=base64` end-to-end.
+ *
+ * The auth/ownership check happens in resolveProxyContext (Supabase user check
+ * + sandbox ownership). Tier routing is automatic — EC2-tier and hosted-tier
+ * sandboxes route to different orchestrator URLs based on `config.tier` on
+ * the sandbox row.
+ */
+
+async function handle(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string; path: string[] }> }
+) {
+    const { id, path } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const subpath = (path || []).join('/')
+    const search = request.nextUrl.search // includes leading '?' or ''
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/fs/${subpath}${search}`
+
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { timeoutMs: 60_000 })
+}
+
+export const GET = handle
+export const POST = handle
+export const PUT = handle
+export const DELETE = handle
+export const PATCH = handle

--- a/app/api/sandbox/[id]/git/[...path]/route.ts
+++ b/app/api/sandbox/[id]/git/[...path]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * Catchall proxy for the sandbox git API.
+ *
+ * Forwards GET/POST under /api/sandbox/[id]/git/... to the orchestrator's
+ * /sandboxes/{sandbox_id}/git/... which delegates to the in-container daemon.
+ *
+ * Endpoints (per orchestrator's matrx_agent daemon):
+ *   POST /git/clone, /git/add, /git/commit, /git/push, /git/pull,
+ *        /git/branch, /git/stash
+ *   GET  /git/status, /git/diff, /git/log
+ *
+ * Long timeout: clones can take a while. Aligns with the orchestrator's
+ * 120s default for /git proxies.
+ */
+
+async function handle(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string; path: string[] }> }
+) {
+    const { id, path } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const subpath = (path || []).join('/')
+    const search = request.nextUrl.search
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/git/${subpath}${search}`
+
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { timeoutMs: 120_000 })
+}
+
+export const GET = handle
+export const POST = handle

--- a/app/api/sandbox/[id]/heartbeat/route.ts
+++ b/app/api/sandbox/[id]/heartbeat/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import {
+    lookupSandboxAndOrchestrator,
+    orchestratorJsonHeaders,
+} from '@/lib/sandbox/orchestrator-routing'
+
+/**
+ * POST /api/sandbox/[id]/heartbeat
+ *
+ * Marks a sandbox as alive. The orchestrator records `last_heartbeat_at` and
+ * keeps the container in 'running' state. Frontend mirrors the same column in
+ * Postgres so UI sees fresh activity timestamps without an extra round-trip.
+ *
+ * Use case: editor sends one of these every ~60s while a sandbox is the
+ * active backend, so the orchestrator's idle-shutdown sweep doesn't reap it.
+ */
+export async function POST(
+    _request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    try {
+        const { id } = await params
+
+        const lookup = await lookupSandboxAndOrchestrator(id)
+        if (!lookup.ok) {
+            return NextResponse.json({ error: lookup.error }, { status: lookup.status })
+        }
+
+        let resp: Response
+        try {
+            resp = await fetch(
+                `${lookup.orchestrator.url}/sandboxes/${lookup.sandboxId}/heartbeat`,
+                { method: 'POST', headers: orchestratorJsonHeaders(lookup.orchestrator) }
+            )
+        } catch (fetchError) {
+            console.error('Orchestrator heartbeat connection failed:', fetchError)
+            return NextResponse.json(
+                { error: 'Sandbox orchestrator is not reachable' },
+                { status: 502 }
+            )
+        }
+
+        if (!resp.ok) {
+            const errBody = await resp.text()
+            return NextResponse.json(
+                { error: 'Heartbeat failed', details: errBody },
+                { status: resp.status >= 500 ? 502 : resp.status }
+            )
+        }
+
+        // Mirror the heartbeat in our DB so listing queries see fresh activity.
+        const supabase = await createClient()
+        await supabase
+            .from('sandbox_instances')
+            .update({ last_heartbeat_at: new Date().toISOString() })
+            .eq('id', id)
+
+        const orchestratorPayload = await resp.json().catch(() => ({}))
+        return NextResponse.json({
+            acknowledged: true,
+            orchestrator: orchestratorPayload,
+        })
+    } catch (error) {
+        console.error('Sandbox heartbeat API error:', error)
+        return NextResponse.json(
+            {
+                error: 'Internal server error',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            },
+            { status: 500 }
+        )
+    }
+}

--- a/app/api/sandbox/[id]/ports/route.ts
+++ b/app/api/sandbox/[id]/ports/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * GET /api/sandbox/[id]/ports
+ *
+ * Lists ports listening **inside** the sandbox container. Note: this is
+ * informational only — there's no public expose-via-Traefik flow yet
+ * (deferred wishlist item). The editor uses this to populate the
+ * "running services" panel and to detect dev servers.
+ */
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const { id } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/ports`
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { timeoutMs: 15_000 })
+}

--- a/app/api/sandbox/[id]/processes/[pid]/signal/route.ts
+++ b/app/api/sandbox/[id]/processes/[pid]/signal/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * POST /api/sandbox/[id]/processes/[pid]/signal
+ *
+ * Body: { "signal": "SIGTERM" | "SIGKILL" | "SIGINT" }
+ *
+ * Used by the editor to cancel a stuck `pnpm install` etc. without destroying
+ * the whole sandbox.
+ */
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string; pid: string }> }
+) {
+    const { id, pid } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/processes/${pid}/signal`
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { timeoutMs: 15_000 })
+}

--- a/app/api/sandbox/[id]/processes/route.ts
+++ b/app/api/sandbox/[id]/processes/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * GET /api/sandbox/[id]/processes
+ *
+ * Returns the list of processes running inside the sandbox (parsed `ps aux`).
+ * Per-process cancellation goes through /api/sandbox/[id]/processes/[pid]/signal.
+ */
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const { id } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/processes`
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { timeoutMs: 15_000 })
+}

--- a/app/api/sandbox/[id]/route.ts
+++ b/app/api/sandbox/[id]/route.ts
@@ -1,19 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/utils/supabase/server'
-
-const ORCHESTRATOR_URL = process.env.MATRX_ORCHESTRATOR_URL || 'http://54.144.86.132:8000'
-const ORCHESTRATOR_API_KEY = process.env.MATRX_ORCHESTRATOR_API_KEY || ''
-
-function orchestratorHeaders(): Record<string, string> {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    if (ORCHESTRATOR_API_KEY) {
-        headers['X-API-Key'] = ORCHESTRATOR_API_KEY
-    }
-    return headers
-}
+import {
+    lookupSandboxAndOrchestrator,
+    orchestratorJsonHeaders,
+} from '@/lib/sandbox/orchestrator-routing'
 
 export async function GET(
-    request: NextRequest,
+    _request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
@@ -60,47 +53,48 @@ export async function GET(
     }
 }
 
+/**
+ * PUT /api/sandbox/[id]
+ *
+ * Body:
+ *   { action: "stop" | "extend", ttl_seconds?: number }
+ *
+ * 'stop'   → calls orchestrator DELETE ?graceful=true, marks DB stopped.
+ * 'extend' → DEPRECATED, use POST /api/sandbox/[id]/extend instead.
+ *            For backward compatibility this still works but now correctly
+ *            forwards to the orchestrator (the prior version only updated
+ *            the DB, which silently drifted from the container's TTL).
+ */
 export async function PUT(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params
-        const supabase = await createClient()
-        const {
-            data: { user },
-            error: userError,
-        } = await supabase.auth.getUser()
-
-        if (userError || !user) {
-            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
-        }
-
         const body = await request.json()
         const { action } = body
 
-        const { data: instance, error: fetchError } = await supabase
-            .from('sandbox_instances')
-            .select('*')
-            .eq('id', id)
-            .eq('user_id', user.id)
-            .single()
-
-        if (fetchError || !instance) {
-            return NextResponse.json({ error: 'Sandbox instance not found' }, { status: 404 })
+        const lookup = await lookupSandboxAndOrchestrator(id)
+        if (!lookup.ok) {
+            return NextResponse.json({ error: lookup.error }, { status: lookup.status })
         }
+
+        const supabase = await createClient()
 
         if (action === 'stop') {
             try {
                 const resp = await fetch(
-                    `${ORCHESTRATOR_URL}/sandboxes/${instance.sandbox_id}?graceful=true`,
-                    { method: 'DELETE', headers: orchestratorHeaders() }
+                    `${lookup.orchestrator.url}/sandboxes/${lookup.sandboxId}?graceful=true`,
+                    { method: 'DELETE', headers: orchestratorJsonHeaders(lookup.orchestrator) }
                 )
                 if (!resp.ok && resp.status !== 404) {
                     console.error('Orchestrator stop failed:', resp.status)
                 }
             } catch (fetchErr) {
-                console.warn('Orchestrator not reachable during stop — updating DB only:', fetchErr instanceof Error ? fetchErr.message : fetchErr)
+                console.warn(
+                    'Orchestrator not reachable during stop — updating DB only:',
+                    fetchErr instanceof Error ? fetchErr.message : fetchErr
+                )
             }
 
             const { data: updated, error: updateError } = await supabase
@@ -126,17 +120,61 @@ export async function PUT(
         }
 
         if (action === 'extend') {
-            const additionalSeconds = body.ttl_seconds || 3600
-            const currentExpiry = instance.expires_at
-                ? new Date(instance.expires_at)
-                : new Date()
-            const newExpiry = new Date(currentExpiry.getTime() + additionalSeconds * 1000)
+            // Forward to the orchestrator first, then mirror its authoritative
+            // expires_at into our DB. The previous DB-only path silently drifted
+            // because the orchestrator runs its own clock for idle/expiry sweeps.
+            const ttlSeconds = Number(body?.ttl_seconds ?? 3600)
+            if (!Number.isFinite(ttlSeconds) || ttlSeconds < 60 || ttlSeconds > 86400) {
+                return NextResponse.json(
+                    { error: 'ttl_seconds must be between 60 and 86400' },
+                    { status: 400 }
+                )
+            }
+
+            let resp: Response
+            try {
+                resp = await fetch(
+                    `${lookup.orchestrator.url}/sandboxes/${lookup.sandboxId}/extend`,
+                    {
+                        method: 'POST',
+                        headers: orchestratorJsonHeaders(lookup.orchestrator),
+                        body: JSON.stringify({ ttl_seconds: ttlSeconds }),
+                    }
+                )
+            } catch (fetchErr) {
+                console.error('Orchestrator extend connection failed:', fetchErr)
+                return NextResponse.json(
+                    { error: 'Sandbox orchestrator is not reachable' },
+                    { status: 502 }
+                )
+            }
+
+            if (!resp.ok) {
+                const errBody = await resp.text()
+                return NextResponse.json(
+                    { error: 'Failed to extend sandbox', details: errBody },
+                    { status: resp.status >= 500 ? 502 : resp.status }
+                )
+            }
+
+            const orchPayload = await resp.json()
+            const newExpiresAt = orchPayload?.new_expires_at || orchPayload?.expires_at
+            if (!newExpiresAt) {
+                return NextResponse.json(
+                    {
+                        error:
+                            'Orchestrator extend returned no expires_at — likely a pre-v0.2.0 stub. ' +
+                            'Update the orchestrator and try again.',
+                    },
+                    { status: 502 }
+                )
+            }
 
             const { data: updated, error: updateError } = await supabase
                 .from('sandbox_instances')
                 .update({
-                    expires_at: newExpiry.toISOString(),
-                    ttl_seconds: instance.ttl_seconds + additionalSeconds,
+                    expires_at: newExpiresAt,
+                    ttl_seconds: ttlSeconds,
                 })
                 .eq('id', id)
                 .select()
@@ -144,12 +182,12 @@ export async function PUT(
 
             if (updateError) {
                 return NextResponse.json(
-                    { error: 'Failed to extend sandbox TTL', details: updateError.message },
+                    { error: 'Failed to mirror extend in DB', details: updateError.message },
                     { status: 500 }
                 )
             }
 
-            return NextResponse.json({ instance: updated })
+            return NextResponse.json({ instance: updated, orchestrator: orchPayload })
         }
 
         return NextResponse.json(
@@ -169,54 +207,42 @@ export async function PUT(
 }
 
 export async function DELETE(
-    request: NextRequest,
+    _request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
     try {
         const { id } = await params
-        const supabase = await createClient()
-        const {
-            data: { user },
-            error: userError,
-        } = await supabase.auth.getUser()
 
-        if (userError || !user) {
-            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
+        const lookup = await lookupSandboxAndOrchestrator(id)
+        if (!lookup.ok) {
+            return NextResponse.json({ error: lookup.error }, { status: lookup.status })
         }
 
-        const { data: instance, error: fetchError } = await supabase
-            .from('sandbox_instances')
-            .select('sandbox_id, status')
-            .eq('id', id)
-            .eq('user_id', user.id)
-            .single()
-
-        if (fetchError || !instance) {
-            return NextResponse.json({ error: 'Sandbox instance not found' }, { status: 404 })
-        }
-
-        if (['creating', 'starting', 'ready', 'running'].includes(instance.status)) {
+        if (['creating', 'starting', 'ready', 'running'].includes(lookup.status)) {
             try {
                 const resp = await fetch(
-                    `${ORCHESTRATOR_URL}/sandboxes/${instance.sandbox_id}?graceful=false`,
-                    { method: 'DELETE', headers: orchestratorHeaders() }
+                    `${lookup.orchestrator.url}/sandboxes/${lookup.sandboxId}?graceful=false`,
+                    { method: 'DELETE', headers: orchestratorJsonHeaders(lookup.orchestrator) }
                 )
                 if (!resp.ok && resp.status !== 404) {
                     console.error('Orchestrator destroy failed:', resp.status)
                 }
             } catch (fetchErr) {
-                console.warn('Orchestrator not reachable during delete — removing DB record only:', fetchErr instanceof Error ? fetchErr.message : fetchErr)
+                console.warn(
+                    'Orchestrator not reachable during delete — removing DB record only:',
+                    fetchErr instanceof Error ? fetchErr.message : fetchErr
+                )
             }
         }
 
-        // Soft delete: set deleted_at timestamp instead of hard deleting
+        const supabase = await createClient()
         const { error: deleteError } = await supabase
             .from('sandbox_instances')
             .update({
                 deleted_at: new Date().toISOString(),
                 status: 'stopped',
-                stopped_at: instance.status !== 'stopped' ? new Date().toISOString() : undefined,
-                stop_reason: 'user_deleted',
+                stopped_at: lookup.status !== 'stopped' ? new Date().toISOString() : undefined,
+                stop_reason: 'user_requested',
             })
             .eq('id', id)
 

--- a/app/api/sandbox/[id]/search/[...path]/route.ts
+++ b/app/api/sandbox/[id]/search/[...path]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from 'next/server'
+import { resolveProxyContext, forwardToOrchestrator } from '@/lib/sandbox/proxy-helpers'
+
+/**
+ * Catchall proxy for sandbox search (ripgrep + fd, in-container daemon).
+ *
+ * /api/sandbox/[id]/search/content → ripgrep wrapper, JSON matches
+ * /api/sandbox/[id]/search/paths   → fd wrapper, glob/fuzzy path matching
+ */
+
+async function handle(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string; path: string[] }> }
+) {
+    const { id, path } = await params
+    const ctx = await resolveProxyContext(id)
+    if (!ctx.ok) return ctx.response
+
+    const subpath = (path || []).join('/')
+    const search = request.nextUrl.search
+    const upstreamUrl = `${ctx.orchestrator.url}/sandboxes/${ctx.sandboxId}/search/${subpath}${search}`
+
+    return forwardToOrchestrator(request, upstreamUrl, ctx.orchestrator, { timeoutMs: 60_000 })
+}
+
+export const GET = handle
+export const POST = handle

--- a/app/api/sandbox/deploy/route.ts
+++ b/app/api/sandbox/deploy/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+
+/**
+ * GET  /api/sandbox/deploy → latest matrx-sandbox GHA deploy status
+ * POST /api/sandbox/deploy → trigger a fresh deploy via workflow_dispatch
+ *
+ * Powers the "deploy state" card on the admin Sandbox Infrastructure panel.
+ * Catches the silent-deploy-failure mode that left EC2 stale for 73 days.
+ *
+ * Requires `MATRX_SANDBOX_GH_TOKEN` env var on the server: a GitHub PAT with
+ * `actions:read,write` scope on `armanisadeghi/matrx-sandbox`. Without it,
+ * GET still works (uses the unauthenticated GitHub API at low rate limits)
+ * and POST returns 501.
+ */
+
+const GH_OWNER = 'armanisadeghi'
+const GH_REPO = 'matrx-sandbox'
+const GH_WORKFLOW = 'deploy.yml'
+const GH_TOKEN = process.env.MATRX_SANDBOX_GH_TOKEN || process.env.GITHUB_TOKEN || ''
+
+function ghHeaders(): Record<string, string> {
+    const h: Record<string, string> = {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
+    if (GH_TOKEN) h.Authorization = `Bearer ${GH_TOKEN}`
+    return h
+}
+
+export async function GET(_request: NextRequest) {
+    try {
+        const supabase = await createClient()
+        const {
+            data: { user },
+            error: userError,
+        } = await supabase.auth.getUser()
+        if (userError || !user) {
+            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
+        }
+
+        const url = `https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/actions/workflows/${GH_WORKFLOW}/runs?per_page=5`
+        const resp = await fetch(url, {
+            headers: ghHeaders(),
+            signal: AbortSignal.timeout(8000),
+        })
+
+        if (!resp.ok) {
+            const txt = await resp.text().catch(() => resp.statusText)
+            return NextResponse.json(
+                { error: 'GitHub API error', status: resp.status, details: txt },
+                { status: 502 }
+            )
+        }
+
+        const data = await resp.json()
+        const runs = (data.workflow_runs || []).slice(0, 5).map((r: Record<string, unknown>) => ({
+            id: r.id,
+            run_number: r.run_number,
+            status: r.status,
+            conclusion: r.conclusion,
+            head_branch: r.head_branch,
+            head_sha: r.head_sha,
+            event: r.event,
+            display_title: r.display_title,
+            actor: (r.actor as Record<string, unknown> | null)?.login,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            run_started_at: r.run_started_at,
+            html_url: r.html_url,
+        }))
+
+        return NextResponse.json({
+            workflow: GH_WORKFLOW,
+            repo: `${GH_OWNER}/${GH_REPO}`,
+            tokenAttached: !!GH_TOKEN,
+            runs,
+        })
+    } catch (error) {
+        console.error('GitHub deploy status fetch error:', error)
+        return NextResponse.json(
+            {
+                error: 'Internal server error',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            },
+            { status: 500 }
+        )
+    }
+}
+
+export async function POST(_request: NextRequest) {
+    try {
+        const supabase = await createClient()
+        const {
+            data: { user },
+            error: userError,
+        } = await supabase.auth.getUser()
+        if (userError || !user) {
+            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
+        }
+
+        if (!GH_TOKEN) {
+            return NextResponse.json(
+                {
+                    error: 'No GitHub token configured (MATRX_SANDBOX_GH_TOKEN)',
+                    details:
+                        'Triggering a deploy requires a PAT with actions:write scope. ' +
+                        'Set MATRX_SANDBOX_GH_TOKEN in Vercel and redeploy.',
+                },
+                { status: 501 }
+            )
+        }
+
+        const url = `https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/actions/workflows/${GH_WORKFLOW}/dispatches`
+        const resp = await fetch(url, {
+            method: 'POST',
+            headers: { ...ghHeaders(), 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ref: 'main' }),
+            signal: AbortSignal.timeout(8000),
+        })
+
+        if (!resp.ok) {
+            const txt = await resp.text().catch(() => resp.statusText)
+            return NextResponse.json(
+                { error: 'Failed to dispatch workflow', status: resp.status, details: txt },
+                { status: 502 }
+            )
+        }
+
+        // GitHub returns 204 with no body for successful dispatch.
+        return NextResponse.json({
+            ok: true,
+            dispatched: true,
+            note: 'GitHub Actions queued the workflow. Refresh the runs list to see progress.',
+        })
+    } catch (error) {
+        console.error('GitHub workflow dispatch error:', error)
+        return NextResponse.json(
+            {
+                error: 'Internal server error',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            },
+            { status: 500 }
+        )
+    }
+}

--- a/app/api/sandbox/route.ts
+++ b/app/api/sandbox/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/utils/supabase/server'
-
-const ORCHESTRATOR_URL = process.env.MATRX_ORCHESTRATOR_URL || 'http://54.144.86.132:8000'
-const ORCHESTRATOR_API_KEY = process.env.MATRX_ORCHESTRATOR_API_KEY || ''
+import {
+    resolveOrchestratorByTier,
+    orchestratorJsonHeaders,
+} from '@/lib/sandbox/orchestrator-routing'
+import type { SandboxConfig, SandboxTier } from '@/types/sandbox'
 
 export async function GET(request: NextRequest) {
     try {
@@ -13,21 +15,18 @@ export async function GET(request: NextRequest) {
         } = await supabase.auth.getUser()
 
         if (userError || !user) {
-            return NextResponse.json(
-                { error: 'User not authenticated' },
-                { status: 401 }
-            )
+            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
         }
 
         const { searchParams } = new URL(request.url)
         const projectId = searchParams.get('project_id')
         const status = searchParams.get('status')
+        const tier = searchParams.get('tier')
         const limit = parseInt(searchParams.get('limit') || '50')
         const offset = parseInt(searchParams.get('offset') || '0')
 
-        // Exclude soft-deleted instances by default
         const includeDeleted = searchParams.get('include_deleted') === 'true'
-        
+
         let query = supabase
             .from('sandbox_instances')
             .select('*', { count: 'exact' })
@@ -38,11 +37,9 @@ export async function GET(request: NextRequest) {
         if (!includeDeleted) {
             query = query.is('deleted_at', null)
         }
-
         if (projectId) {
             query = query.eq('project_id', projectId)
         }
-
         if (status) {
             query = query.eq('status', status)
         }
@@ -57,8 +54,18 @@ export async function GET(request: NextRequest) {
             )
         }
 
+        // Optional client-side tier filter — we store tier in `config` (JSONB)
+        // until we promote it to a column, so a SQL-side filter would need a
+        // JSON path operator. Filtering in JS is fine for the modest list size.
+        let instances = data || []
+        if (tier) {
+            instances = instances.filter(
+                (row) => (row.config as SandboxConfig | null)?.tier === tier
+            )
+        }
+
         return NextResponse.json({
-            instances: data || [],
+            instances,
             pagination: {
                 total: count || 0,
                 limit,
@@ -87,14 +94,29 @@ export async function POST(request: NextRequest) {
         } = await supabase.auth.getUser()
 
         if (userError || !user) {
-            return NextResponse.json(
-                { error: 'User not authenticated' },
-                { status: 401 }
-            )
+            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
         }
 
         const body = await request.json()
-        const { project_id, config, ttl_seconds } = body
+        const {
+            project_id,
+            config,
+            ttl_seconds,
+            tier: tierInput,
+            template,
+            template_version,
+            resources,
+            labels,
+        } = body as {
+            project_id?: string
+            config?: SandboxConfig
+            ttl_seconds?: number
+            tier?: SandboxTier
+            template?: string
+            template_version?: string
+            resources?: { cpu?: number; memory_mb?: number; disk_mb?: number }
+            labels?: Record<string, string>
+        }
 
         if (project_id) {
             const { data: project, error: projectError } = await supabase
@@ -104,10 +126,7 @@ export async function POST(request: NextRequest) {
                 .single()
 
             if (projectError || !project) {
-                return NextResponse.json(
-                    { error: 'Project not found' },
-                    { status: 404 }
-                )
+                return NextResponse.json({ error: 'Project not found' }, { status: 404 })
             }
         }
 
@@ -119,47 +138,71 @@ export async function POST(request: NextRequest) {
 
         if (!countError && activeInstances && activeInstances.length >= 5) {
             return NextResponse.json(
-                { error: 'Maximum active sandbox limit reached (5). Stop an existing sandbox first.' },
+                {
+                    error:
+                        'Maximum active sandbox limit reached (5). Stop an existing sandbox first.',
+                },
                 { status: 429 }
             )
         }
 
-        const orchestratorHeaders: Record<string, string> = {
-            'Content-Type': 'application/json',
+        // Resolve tier — explicit > config.tier > default 'ec2' for back-compat.
+        const tier: SandboxTier = tierInput || (config?.tier as SandboxTier) || 'ec2'
+        const target = resolveOrchestratorByTier(tier)
+
+        // Forward to the matching orchestrator.
+        const orchestratorBody: Record<string, unknown> = {
+            user_id: user.id,
+            config: config || {},
+            tier,
         }
-        if (ORCHESTRATOR_API_KEY) {
-            orchestratorHeaders['X-API-Key'] = ORCHESTRATOR_API_KEY
-        }
+        if (template) orchestratorBody.template = template
+        if (template_version) orchestratorBody.template_version = template_version
+        if (resources) orchestratorBody.resources = resources
+        if (labels) orchestratorBody.labels = labels
+        if (ttl_seconds) orchestratorBody.ttl_seconds = ttl_seconds
 
         let orchestratorResp: Response
         try {
-            orchestratorResp = await fetch(`${ORCHESTRATOR_URL}/sandboxes`, {
+            orchestratorResp = await fetch(`${target.url}/sandboxes`, {
                 method: 'POST',
-                headers: orchestratorHeaders,
-                body: JSON.stringify({
-                    user_id: user.id,
-                    config: config || {},
-                }),
+                headers: orchestratorJsonHeaders(target),
+                body: JSON.stringify(orchestratorBody),
             })
         } catch (fetchError) {
-            console.error('Orchestrator connection failed:', fetchError)
+            console.error(`Orchestrator (${tier}) connection failed:`, fetchError)
             return NextResponse.json(
-                { error: 'Sandbox orchestrator is not reachable. Ensure the orchestrator service is running.' },
+                {
+                    error: `Sandbox orchestrator (${tier}) is not reachable. Ensure the orchestrator service is running.`,
+                },
                 { status: 502 }
             )
         }
 
         if (!orchestratorResp.ok) {
             const errBody = await orchestratorResp.text()
-            console.error('Orchestrator create failed:', orchestratorResp.status, errBody)
+            console.error(`Orchestrator create (${tier}) failed:`, orchestratorResp.status, errBody)
             return NextResponse.json(
                 { error: 'Failed to create sandbox container', details: errBody },
-                { status: 502 }
+                { status: orchestratorResp.status === 400 ? 400 : 502 }
             )
         }
 
         const orchestratorData = await orchestratorResp.json()
-        const effectiveTtl = ttl_seconds || 7200
+        const effectiveTtl = ttl_seconds || orchestratorData?.ttl_seconds || 7200
+
+        // Pack tier/template/resources/labels into config until we have dedicated
+        // columns (a follow-up Supabase migration). The orchestrator's response
+        // also includes these fields as top-level — we keep our copy in `config`
+        // for the routing logic in lookupSandboxAndOrchestrator.
+        const persistedConfig: SandboxConfig = {
+            ...(config || {}),
+            tier,
+            ...(template ? { template } : {}),
+            ...(template_version ? { template_version } : {}),
+            ...(resources ? { resources } : {}),
+            ...(labels ? { labels } : {}),
+        }
 
         const sandboxRecord = {
             user_id: user.id,
@@ -169,14 +212,13 @@ export async function POST(request: NextRequest) {
             container_id: orchestratorData.container_id,
             hot_path: orchestratorData.hot_path || '/home/agent',
             cold_path: orchestratorData.cold_path || '/data/cold',
-            config: config || {},
+            config: persistedConfig,
             ttl_seconds: effectiveTtl,
-            expires_at: new Date(Date.now() + effectiveTtl * 1000).toISOString(),
+            expires_at:
+                orchestratorData.expires_at ||
+                new Date(Date.now() + effectiveTtl * 1000).toISOString(),
         }
 
-        // Use upsert to handle orphaned records — if the orchestrator returns a sandbox_id
-        // that already exists in the DB (from a previous failed/expired attempt), update it
-        // instead of failing with a duplicate key error.
         const { data: instance, error: insertError } = await supabase
             .from('sandbox_instances')
             .upsert(sandboxRecord, { onConflict: 'sandbox_id' })

--- a/app/api/sandbox/system/route.ts
+++ b/app/api/sandbox/system/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import {
+    resolveOrchestratorByTier,
+    orchestratorJsonHeaders,
+} from '@/lib/sandbox/orchestrator-routing'
+import type { SandboxTier } from '@/types/sandbox'
+
+/**
+ * GET /api/sandbox/system?tier=ec2|hosted
+ *
+ * Aggregates host pressure (disk/mem/cpu) + container counts from one or both
+ * orchestrators. Powers the admin Sandbox Infrastructure panel.
+ *
+ * - Without `tier`: returns both tiers in a single response.
+ * - With `tier`: returns just that tier.
+ *
+ * Auth: requires a Supabase session (any authenticated user). The orchestrator
+ * itself enforces an API key — that's added server-side from env, never exposed
+ * to the browser.
+ */
+
+interface OrchestratorSystemInfo {
+    tier: SandboxTier
+    url: string
+    ok: boolean
+    status: 'healthy' | 'unreachable' | 'error'
+    error?: string
+    /** Raw payload from {orchestrator}/system when ok */
+    system?: Record<string, unknown>
+    /** Raw payload from {orchestrator}/ when ok */
+    info?: Record<string, unknown>
+    /** Raw /api-surface route count when ok */
+    routeCount?: number
+    fetchedAt: string
+}
+
+async function fetchTierInfo(tier: SandboxTier): Promise<OrchestratorSystemInfo> {
+    const target = resolveOrchestratorByTier(tier)
+    const fetchedAt = new Date().toISOString()
+    const headers = orchestratorJsonHeaders(target)
+
+    try {
+        // Three reads in parallel: /system (auth) + / (no auth) + /api-surface (no auth)
+        const [systemResp, rootResp, surfaceResp] = await Promise.allSettled([
+            fetch(`${target.url}/system`, { headers, signal: AbortSignal.timeout(8000) }),
+            fetch(`${target.url}/`, { signal: AbortSignal.timeout(5000) }),
+            fetch(`${target.url}/api-surface`, { signal: AbortSignal.timeout(5000) }),
+        ])
+
+        const sys =
+            systemResp.status === 'fulfilled' && systemResp.value.ok
+                ? await systemResp.value.json().catch(() => undefined)
+                : undefined
+        const info =
+            rootResp.status === 'fulfilled' && rootResp.value.ok
+                ? await rootResp.value.json().catch(() => undefined)
+                : undefined
+        const surface =
+            surfaceResp.status === 'fulfilled' && surfaceResp.value.ok
+                ? await surfaceResp.value.json().catch(() => undefined)
+                : undefined
+
+        const reachable = sys || info
+        if (!reachable) {
+            return {
+                tier,
+                url: target.url,
+                ok: false,
+                status: 'unreachable',
+                error: 'Orchestrator did not respond to /, /system, or /api-surface',
+                fetchedAt,
+            }
+        }
+
+        return {
+            tier,
+            url: target.url,
+            ok: true,
+            status: 'healthy',
+            system: sys,
+            info,
+            routeCount: surface?.routes?.length,
+            fetchedAt,
+        }
+    } catch (err) {
+        return {
+            tier,
+            url: target.url,
+            ok: false,
+            status: 'error',
+            error: err instanceof Error ? err.message : 'Unknown error',
+            fetchedAt,
+        }
+    }
+}
+
+export async function GET(request: NextRequest) {
+    try {
+        const supabase = await createClient()
+        const {
+            data: { user },
+            error: userError,
+        } = await supabase.auth.getUser()
+
+        if (userError || !user) {
+            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
+        }
+
+        const tierParam = request.nextUrl.searchParams.get('tier') as SandboxTier | null
+        const tiers: SandboxTier[] = tierParam ? [tierParam] : ['ec2', 'hosted']
+
+        const results = await Promise.all(tiers.map(fetchTierInfo))
+        return NextResponse.json({ tiers: results })
+    } catch (error) {
+        console.error('Sandbox system API error:', error)
+        return NextResponse.json(
+            {
+                error: 'Internal server error',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            },
+            { status: 500 }
+        )
+    }
+}

--- a/app/api/templates/route.ts
+++ b/app/api/templates/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import {
+    resolveOrchestratorByTier,
+    orchestratorJsonHeaders,
+} from '@/lib/sandbox/orchestrator-routing'
+import type { SandboxTier } from '@/types/sandbox'
+
+/**
+ * GET /api/templates?tier=ec2|hosted
+ *
+ * Returns the list of sandbox templates available on the requested tier.
+ * Defaults to 'ec2' for backward compatibility. Each tier's orchestrator
+ * advertises its own template list via /templates — they may differ if the
+ * two tiers ship different images.
+ *
+ * The auth check is the standard Supabase user check; no per-template ACLs.
+ */
+export async function GET(request: NextRequest) {
+    try {
+        const supabase = await createClient()
+        const {
+            data: { user },
+            error: userError,
+        } = await supabase.auth.getUser()
+
+        if (userError || !user) {
+            return NextResponse.json({ error: 'User not authenticated' }, { status: 401 })
+        }
+
+        const tierParam = request.nextUrl.searchParams.get('tier') as SandboxTier | null
+        const tier: SandboxTier = tierParam === 'hosted' ? 'hosted' : 'ec2'
+        const target = resolveOrchestratorByTier(tier)
+
+        let resp: Response
+        try {
+            resp = await fetch(`${target.url}/templates`, {
+                method: 'GET',
+                headers: orchestratorJsonHeaders(target),
+            })
+        } catch (fetchError) {
+            console.error(`Orchestrator templates fetch failed (${tier}):`, fetchError)
+            return NextResponse.json(
+                { error: `Orchestrator (${tier}) is not reachable` },
+                { status: 502 }
+            )
+        }
+
+        if (!resp.ok) {
+            // Pre-v0.2.0 orchestrators don't have /templates yet — fall back to
+            // a hardcoded default so the create dialog still works.
+            if (resp.status === 404) {
+                return NextResponse.json({
+                    templates: [
+                        {
+                            id: 'bare',
+                            version: '1',
+                            description: 'Default sandbox.',
+                            image: 'matrx-sandbox:latest',
+                            tier,
+                            languages: ['python', 'node', 'bash'],
+                        },
+                    ],
+                    fallback: true,
+                })
+            }
+            const errBody = await resp.text()
+            return NextResponse.json(
+                { error: 'Failed to fetch templates', details: errBody },
+                { status: resp.status >= 500 ? 502 : resp.status }
+            )
+        }
+
+        const data = await resp.json()
+        return NextResponse.json(data)
+    } catch (error) {
+        console.error('Templates API error:', error)
+        return NextResponse.json(
+            {
+                error: 'Internal server error',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            },
+            { status: 500 }
+        )
+    }
+}

--- a/features/code/SYSTEM_STATE.md
+++ b/features/code/SYSTEM_STATE.md
@@ -1,9 +1,11 @@
 # `/code` Workspace — System State & Gap Audit
 
-**Last updated:** 2026‑04‑25
+**Last updated:** 2026‑04‑26
 **Scope:** Everything under `features/code/`, plus its hooks, adapters, and the slices it consumes from elsewhere in the app.
 
 This doc is the single source of truth for the `/code` (VSCode‑style) workspace. It captures (1) what is shipped, (2) what is wired but incomplete, (3) what is intentionally deferred, and (4) the shape of the next four work items: Monaco type environments, sandbox API delivery audit, editor→agent context protocol, and known‑environment settings.
+
+> **2026-04-26 update:** the sandbox API audit in §3 has been rewritten — the previous "wishlist not delivered" verdict was based on probing `/openapi.json` against a stale EC2 deploy. The actual orchestrator code (v0.2.0) implements the rich proxy surface, but the proxy routes use `@router.api_route` with broad path catchalls that don't surface in OpenAPI the same way. There is also a new self-hosted "hosted-tier" orchestrator at `https://orchestrator.dev.codematrx.com` — see §3 below.
 
 ---
 
@@ -245,60 +247,50 @@ There is no Git activity view yet. The plan is `features/code/views/source-contr
 
 ---
 
-## 3. Sandbox API delivery audit
+## 3. Sandbox API delivery audit (revised 2026‑04‑26)
 
-I probed the orchestrator directly:
+The orchestrator code on disk (v0.2.0) implements the full rich surface. The previous "only 8 endpoints" finding came from probing `/openapi.json`, which omits routes registered with `@router.api_route("/{sandbox_id}/fs/{path:path}", methods=[...])`-style catchalls. The new authoritative discovery endpoint is `GET /api-surface` — frontends should use that instead.
 
-```bash
-curl -sS http://54.144.86.132:8000/openapi.json | jq '.paths | keys'
-```
+There are now **two orchestrators**:
 
-Result (verbatim):
+| Tier | URL | Backed by |
+|---|---|---|
+| `ec2` | `http://54.144.86.132:8000` | EC2 host, S3 hot/cold, Supabase Postgres |
+| `hosted` | `https://orchestrator.dev.codematrx.com` | Matrx dev server, Docker volumes, in‑memory store today |
 
-```
-[
-  "/",
-  "/health",
-  "/sandboxes",
-  "/sandboxes/{sandbox_id}",
-  "/sandboxes/{sandbox_id}/complete",
-  "/sandboxes/{sandbox_id}/error",
-  "/sandboxes/{sandbox_id}/exec",
-  "/sandboxes/{sandbox_id}/heartbeat"
-]
-```
+Sandboxes carry a `tier` field (persisted in `sandbox_instances.config.tier`) so the proxy routes can forward to the right orchestrator. See `lib/sandbox/orchestrator-routing.ts`.
 
-### 3.1 Wishlist scoreboard
+### 3.1 Wishlist scoreboard (orchestrator code v0.2.0)
 
-| Wishlist item | Priority | Delivered? | Notes |
-|---------------|----------|------------|-------|
-| §3.1.1 Structured FS API (`/fs/list /stat /read /write /patch /delete /mkdir /rename /copy`) | P0 | ❌ | None of the 9 endpoints exist. |
-| §3.1.2 Streaming `exec` (SSE / WebSocket, with stdin/env/cancel) | P0 | ❌ | `/exec` is still buffered JSON; no `stdin`, `env`, or cancel. `command` cap still 10 KB. |
-| §3.1.3 Real PTY WebSocket | P0 | ❌ | No `wss` route. |
-| §3.1.4 Git workflow primitives (`/git/clone /status /diff /add /commit /push /pull /branch /stash /log`) | P0 | ❌ | Not present. |
-| §3.1.5 Git credential model (`/credentials`) | P0 | ❌ | Not present. |
-| §3.1.6 Template selection at create time | P0 | ❌ | `CreateSandboxRequest` still `{ user_id, config }` — no `template`, `template_version`, `resources`, `labels`. |
-| §3.1.7 TTL / heartbeat | P0 | 🟡 partial | `POST /sandboxes/{id}/heartbeat` exists. **No `extend` endpoint** — our `extend` route still drifts the DB. |
-| §3.2.1 File watcher | P1 | ❌ | |
-| §3.2.2 Server‑side search (ripgrep) | P1 | ❌ | |
-| §3.2.3 Bulk fs ops + upload/download | P1 | ❌ | |
-| §3.2.4 Process management | P1 | ❌ | |
-| §3.2.5 Port forwarding | P1 | ❌ | |
-| §3.3.* Snapshot / multi‑user / LSP / AI sockets | P2 | ❌ | |
-| (new) `POST /sandboxes/{id}/complete` | n/a | ✨ | Not in the wishlist. Agent self‑signals task completion → graceful shutdown. |
-| (new) `POST /sandboxes/{id}/error` | n/a | ✨ | Not in the wishlist. Agent self‑reports error → graceful shutdown. |
+| Wishlist item | Priority | Code on disk | EC2 deploy | Hosted deploy | Frontend |
+|---|---|---|---|---|---|
+| §3.1.1 Structured FS API (list/stat/read/write/patch/delete/mkdir/rename/copy/upload/download/batch) | P0 | ✅ | 🚀 stale (deploy disk-full; see matrx-sandbox `docs/OPERATIONS.md`) | ✅ live | ✅ `SandboxFilesystemAdapter` rewritten 2026‑04‑26 |
+| §3.1.2 Streaming `exec` (SSE) with env/stdin | P0 | ✅ | 🚀 | ✅ | ✅ `SandboxProcessAdapter.stream()` |
+| §3.1.3 Real PTY WebSocket | P0 | ✅ | 🚀 | ✅ | ⏳ `TerminalTab` rewrite still pending |
+| §3.1.4 Git workflow primitives | P0 | ✅ | 🚀 | ✅ | ✅ `SandboxGitAdapter` |
+| §3.1.5 Git credential model | P0 | ✅ | 🚀 | ✅ | ✅ via `SandboxGitAdapter.setGithubToken/...` |
+| §3.1.6 Template selection at create time | P0 | ✅ (`template`, `template_version`, `tier`, `resources`, `labels`) | 🚀 | ✅ | ✅ create flow accepts these (Sandboxes panel UI still pending) |
+| §3.1.7 TTL `extend` (persists `expires_at`) + heartbeat | P0 | ✅ | 🚀 | ✅ | ✅ `/api/sandbox/[id]/extend` + `useSandboxHeartbeat` |
+| §3.2.1 File watcher (WebSocket) | P1 | ✅ `/fs/watch` | 🚀 | ✅ | ✅ `SandboxFilesystemAdapter.watch()` |
+| §3.2.2 Server‑side search (ripgrep + fd) | P1 | ✅ `/search/{path}` | 🚀 | ✅ | ✅ `searchContent` / `searchPaths` on the adapter |
+| §3.2.3 Bulk fs / upload / download | P1 | ✅ in daemon | 🚀 | ✅ | ⏳ adapter helpers pending |
+| §3.2.4 Process listing + signal | P1 | ✅ `/processes` | 🚀 | ✅ | ✅ proxy routes; consumer pending |
+| §3.2.5 Port listing | P1 | ✅ `/ports` | 🚀 | ✅ | ✅ proxy route; consumer pending |
+| §3.2.5 Public preview URL exposure | P1 | ❌ | — | — | — |
+| §3.3.* Snapshot / multi‑user / LSP / AI sockets | P2 | ❌ | — | — | — |
+| (new) `POST /sandboxes/{id}/complete` | n/a | ✅ | ✅ | ✅ | not consumed |
+| (new) `POST /sandboxes/{id}/error` | n/a | ✅ | ✅ | ✅ | not consumed |
+| (new) `GET /api-surface` | n/a | ✅ v0.2.0 | 🚀 | ✅ | not consumed (use for capability discovery) |
 
-**Net delivery:** 1 partial (§3.1.7 heartbeat only — `extend` missing), 0 full, 16 not started.
+**Net delivery:** Every P0 surface shipped in code; hosted tier is fully live; EC2 deploy is blocked by an infra issue (host disk full). Frontend has caught up on backends/adapters; `TerminalTab` PTY rewrite + bulk upload UI are the remaining client gaps.
 
-### 3.2 Recommendation
+### 3.2 Discovery — use `/api-surface`, not `/openapi.json`
 
-I think the most likely explanation is that "the wishlist is done" was scoped to a **different** wishlist than the one in `features/code/SANDBOX_API_WISHLIST.md`, or it was misreported. Concrete next step:
+Both orchestrators expose `GET /api-surface` (no auth). It returns the authoritative route list including the catchall proxy routes, plus `tier` and `version`. Use this when documenting capabilities or detecting feature support. The `/openapi.json` schema is incomplete — keep it for human reference only.
 
-1. Forward this section as a Markdown excerpt to the orchestrator team with the note: *"Verified live against `/openapi.json` — only `heartbeat` shows up. Please confirm whether the wishlist work is on a different branch / feature flag, or if there was a scope mismatch."*
-2. While we wait, ship the heartbeat client (we already have it in the editor — just need to invoke it) so the TTL drift bug closes.
-3. Hold the `SandboxFilesystemAdapter` rewrite until §3.1.1 lands. Anything we'd write today against the current shell layer is throwaway.
+### 3.3 EC2 deploy resilience
 
-A patch for the `/api/sandbox/[id]/heartbeat` proxy route + a hook (`useSandboxHeartbeat`) is small and unblocking and will be done in a follow‑up.
+The two prior deploy failures and the 2026‑04‑26 attempt all failed at "Deploy to EC2 via SSM" with `failed to register layer: ... no space left on device`. Remediation belongs to the matrx-sandbox ops side (prune Docker on the host, add a workflow `docker system prune -af` step before `docker pull`). Until that lands, the EC2 tier stays on pre-wishlist code; the hosted tier (this server) is unaffected.
 
 ---
 

--- a/features/code/adapters/FilesystemAdapter.ts
+++ b/features/code/adapters/FilesystemAdapter.ts
@@ -1,18 +1,24 @@
-import type { FilesystemNode, FilesystemWatchEvent } from "../types";
+import type {
+  FilesystemNode,
+  FilesystemSearchHit,
+  FilesystemStat,
+  FilesystemWatchEvent,
+} from "../types";
 
 /**
  * Adapter interface for all filesystem sources.
  *
  * Implementations:
  *  - MockFilesystemAdapter — static in-memory project for demos/tests.
- *  - SandboxFilesystemAdapter — proxies to /api/sandbox/[id]/exec for a live
- *    Coolify-hosted sandbox container.
- *  - (future) AwsFilesystemAdapter — reads the user's cloud project stored
- *    on AWS.
+ *  - SandboxFilesystemAdapter — talks to /api/sandbox/[id]/fs/* (proxies the
+ *    rich orchestrator filesystem API; binary-safe, atomic writes, watcher).
  *
  * The adapter is the single boundary between the workspace UI and whatever
  * storage/runtime is backing it. Keep it narrow; prefer separate adapter
  * methods over plumbing conditionals through the UI.
+ *
+ * Methods marked optional may be unimplemented by simpler adapters (Mock).
+ * UI code should feature-detect (`if (adapter.stat)`).
  */
 export interface FilesystemAdapter {
   /** Stable identifier — prefixed to file ids so they survive adapter swaps. */
@@ -27,9 +33,44 @@ export interface FilesystemAdapter {
   listChildren(path: string): Promise<FilesystemNode[]>;
   readFile(path: string): Promise<string>;
   writeFile?(path: string, content: string): Promise<void>;
+
+  /** Optional — single-file stat. */
+  stat?(path: string): Promise<FilesystemStat>;
+  /** Optional — read a binary file as base64. */
+  readFileBinary?(path: string): Promise<string>;
+  /** Optional — write base64-encoded binary content. */
+  writeFileBinary?(path: string, base64: string): Promise<void>;
+  /** Optional — make a directory (mkdir -p when `parents` is true). */
+  mkdir?(path: string, parents?: boolean): Promise<void>;
+  /** Optional — delete a file or directory. */
+  delete?(path: string, recursive?: boolean): Promise<void>;
+  /** Optional — atomic rename. */
+  rename?(fromPath: string, toPath: string, overwrite?: boolean): Promise<void>;
+  /** Optional — copy a file or directory. */
+  copy?(fromPath: string, toPath: string, recursive?: boolean): Promise<void>;
+
   /**
    * Optional subscription. Adapters without a live backend can omit this; the
    * workspace will fall back to explicit refresh actions.
    */
   watch?(path: string, cb: (ev: FilesystemWatchEvent) => void): () => void;
+
+  /** Optional — server-side content search (ripgrep). Streams matches via cb. */
+  searchContent?(opts: {
+    query: string;
+    regex?: boolean;
+    caseSensitive?: boolean;
+    includeGlobs?: string[];
+    excludeGlobs?: string[];
+    maxResults?: number;
+    onHit: (hit: FilesystemSearchHit) => void;
+    signal?: AbortSignal;
+  }): Promise<{ truncated: boolean }>;
+
+  /** Optional — server-side path search (fd). */
+  searchPaths?(opts: {
+    pattern: string;
+    fuzzy?: boolean;
+    maxResults?: number;
+  }): Promise<string[]>;
 }

--- a/features/code/adapters/ProcessAdapter.ts
+++ b/features/code/adapters/ProcessAdapter.ts
@@ -18,17 +18,29 @@ export interface ProcessAdapter {
 
   exec(
     command: string,
-    opts?: { cwd?: string; timeoutSec?: number },
+    opts?: {
+      cwd?: string;
+      timeoutSec?: number;
+      env?: Record<string, string>;
+      stdin?: string;
+    },
   ): Promise<ProcessResult>;
 
   /**
-   * Optional live stream. Not required for v1 — `exec` alone drives the UI.
-   * When implemented, consumers should still `await exec(...)` for the final
-   * exit code; `stream` supplies incremental chunks in the meantime.
+   * Optional live stream. Backed by the orchestrator's /exec/stream SSE
+   * endpoint — incremental stdout/stderr arrive via `onEvent`, and the final
+   * `ProcessResult` resolves with the exit code. Cancellation: pass an
+   * AbortSignal; aborting closes the SSE which signals the orchestrator to
+   * SIGTERM the running command.
    */
   stream?(
     command: string,
     onEvent: (ev: ProcessEvent) => void,
-    opts?: { cwd?: string; signal?: AbortSignal },
+    opts?: {
+      cwd?: string;
+      env?: Record<string, string>;
+      stdin?: string;
+      signal?: AbortSignal;
+    },
   ): Promise<ProcessResult>;
 }

--- a/features/code/adapters/SandboxFilesystemAdapter.ts
+++ b/features/code/adapters/SandboxFilesystemAdapter.ts
@@ -1,13 +1,31 @@
 import type { FilesystemAdapter } from "./FilesystemAdapter";
-import type { FilesystemNode } from "../types";
+import type {
+  FilesystemNode,
+  FilesystemSearchHit,
+  FilesystemStat,
+  FilesystemWatchEvent,
+} from "../types";
+
+interface DaemonEntry {
+  name: string;
+  path: string;
+  kind: "file" | "dir" | "symlink";
+  size: number;
+  mtime: number;
+  mode: number;
+  target?: string | null;
+}
 
 /**
- * Adapter that talks to the existing /api/sandbox/[id]/exec endpoint.
+ * Adapter that talks to the orchestrator's structured filesystem API via
+ * /api/sandbox/[id]/fs/* (which forwards into the in-container matrx_agent
+ * daemon). Binary-safe via base64 encoding, atomic writes, and a real change
+ * watcher.
  *
- * Directory listings are produced by executing `ls -lA --time-style=...` and
- * parsing the output. File reads are `cat`; writes encode the content into a
- * here-doc. All commands are funneled through the same authenticated route
- * that powers app/(authenticated)/sandbox/[id].
+ * The previous shell-based implementation (`ls -lA`/`cat`/`base64 -d`) is
+ * gone — it broke for binary files, files larger than ~7.5KB (after base64
+ * bloat against the 10K command cap), and any directory listing involving
+ * filenames with spaces or non-ASCII characters.
  */
 export class SandboxFilesystemAdapter implements FilesystemAdapter {
   readonly id: string;
@@ -26,57 +44,48 @@ export class SandboxFilesystemAdapter implements FilesystemAdapter {
     this.rootPath = rootPath;
   }
 
-  private async exec(command: string): Promise<{
-    stdout: string;
-    stderr: string;
-    exit_code: number;
-  }> {
-    const resp = await fetch(`/api/sandbox/${this.instanceId}/exec`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ command, timeout: 30 }),
-    });
-    if (!resp.ok) {
-      const errBody = await resp.text().catch(() => resp.statusText);
-      throw new Error(`exec failed (${resp.status}): ${errBody}`);
-    }
-    return resp.json();
+  // ── private HTTP helpers ───────────────────────────────────────────────────
+
+  private url(subpath: string, query?: Record<string, string | undefined>): string {
+    const qs = query
+      ? "?" +
+        Object.entries(query)
+          .filter(([, v]) => v !== undefined && v !== null && v !== "")
+          .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v as string)}`)
+          .join("&")
+      : "";
+    return `/api/sandbox/${this.instanceId}/fs/${subpath}${qs}`;
   }
 
-  async listChildren(path: string): Promise<FilesystemNode[]> {
-    const escaped = path.replace(/'/g, "'\\''");
-    const cmd = `ls -lA --time-style=long-iso '${escaped}' 2>/dev/null | tail -n +2`;
-    const { stdout } = await this.exec(cmd);
-    if (!stdout.trim()) return [];
-
-    const nodes: FilesystemNode[] = [];
-    for (const line of stdout.split("\n")) {
-      if (!line.trim()) continue;
-      // drwxr-xr-x 2 agent agent 4096 2024-01-15 10:30 name
-      const parts = line.split(/\s+/);
-      if (parts.length < 8) continue;
-      const perms = parts[0];
-      const sizeStr = parts[4];
-      const name = parts.slice(7).join(" ");
-      if (!name || name === "." || name === "..") continue;
-
-      const kind: "file" | "directory" = perms.startsWith("d")
-        ? "directory"
-        : "file";
-      const full =
-        path === "/" ? `/${name}` : `${path.replace(/\/+$/, "")}/${name}`;
-      nodes.push({
-        path: full,
-        name,
-        kind,
-        size:
-          kind === "file"
-            ? Number.parseInt(sizeStr, 10) || undefined
-            : undefined,
-        modifiedAt: `${parts[5]}T${parts[6]}`,
-      });
+  private async req<T>(
+    subpath: string,
+    init: RequestInit & { query?: Record<string, string | undefined> } = {},
+  ): Promise<T> {
+    const { query, ...rest } = init;
+    const resp = await fetch(this.url(subpath, query), rest);
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`fs ${rest.method ?? "GET"} ${subpath} failed (${resp.status}): ${text}`);
     }
+    const ct = resp.headers.get("content-type") || "";
+    if (ct.includes("application/json")) {
+      return resp.json() as Promise<T>;
+    }
+    // For binary reads we expect text or raw bytes — caller decodes.
+    return (await resp.text()) as unknown as T;
+  }
 
+  // ── core methods ───────────────────────────────────────────────────────────
+
+  async listChildren(path: string): Promise<FilesystemNode[]> {
+    const data = await this.req<{ entries: DaemonEntry[] }>("list", { query: { path } });
+    const nodes: FilesystemNode[] = (data.entries ?? []).map((e) => ({
+      path: e.path,
+      name: e.name,
+      kind: e.kind === "dir" ? "directory" : "file",
+      size: e.kind === "file" ? e.size : undefined,
+      modifiedAt: e.mtime ? new Date(e.mtime * 1000).toISOString() : undefined,
+    }));
     nodes.sort((a, b) => {
       if (a.kind !== b.kind) return a.kind === "directory" ? -1 : 1;
       return a.name.localeCompare(b.name);
@@ -84,26 +93,187 @@ export class SandboxFilesystemAdapter implements FilesystemAdapter {
     return nodes;
   }
 
+  async stat(path: string): Promise<FilesystemStat> {
+    const e = await this.req<DaemonEntry>("stat", { query: { path } });
+    return {
+      path: e.path,
+      kind: e.kind === "dir" ? "directory" : e.kind === "symlink" ? "symlink" : "file",
+      size: e.size,
+      mode: e.mode,
+      modifiedAt: e.mtime ? new Date(e.mtime * 1000).toISOString() : undefined,
+      target: e.target ?? undefined,
+    };
+  }
+
   async readFile(path: string): Promise<string> {
-    const escaped = path.replace(/'/g, "'\\''");
-    const { stdout, stderr, exit_code } = await this.exec(`cat '${escaped}'`);
-    if (exit_code !== 0) {
-      throw new Error(stderr || `cat exited ${exit_code}`);
+    const resp = await fetch(this.url("read", { path, encoding: "utf8" }));
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`read failed (${resp.status}): ${text}`);
     }
-    return stdout;
+    return resp.text();
+  }
+
+  async readFileBinary(path: string): Promise<string> {
+    // The daemon returns base64 in a JSON envelope when encoding=base64.
+    const data = await this.req<{ content: string; encoding: "base64" }>("read", {
+      query: { path, encoding: "base64" },
+    });
+    return data.content;
   }
 
   async writeFile(path: string, content: string): Promise<void> {
-    const escapedPath = path.replace(/'/g, "'\\''");
-    // Base64-encode to survive shell quoting of arbitrary binary/text.
-    const encoded =
-      typeof window === "undefined"
-        ? Buffer.from(content, "utf8").toString("base64")
-        : btoa(unescape(encodeURIComponent(content)));
-    const cmd = `echo '${encoded}' | base64 -d > '${escapedPath}'`;
-    const { stderr, exit_code } = await this.exec(cmd);
-    if (exit_code !== 0) {
-      throw new Error(stderr || `write exited ${exit_code}`);
+    await this.req("write", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path, content, encoding: "utf8", create_parents: true }),
+    });
+  }
+
+  async writeFileBinary(path: string, base64: string): Promise<void> {
+    await this.req("write", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path, content: base64, encoding: "base64", create_parents: true }),
+    });
+  }
+
+  async mkdir(path: string, parents: boolean = true): Promise<void> {
+    await this.req("mkdir", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path, parents }),
+    });
+  }
+
+  async delete(path: string, recursive: boolean = false): Promise<void> {
+    await this.req("delete", {
+      method: "DELETE",
+      query: { path, recursive: recursive ? "true" : "false" },
+    });
+  }
+
+  async rename(fromPath: string, toPath: string, overwrite: boolean = false): Promise<void> {
+    await this.req("rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from_path: fromPath, to_path: toPath, overwrite }),
+    });
+  }
+
+  async copy(fromPath: string, toPath: string, recursive: boolean = true): Promise<void> {
+    await this.req("copy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from_path: fromPath, to_path: toPath, recursive }),
+    });
+  }
+
+  // ── change watcher (WebSocket) ─────────────────────────────────────────────
+
+  watch(path: string, cb: (ev: FilesystemWatchEvent) => void): () => void {
+    if (typeof window === "undefined") {
+      return () => {};
     }
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${proto}//${window.location.host}/api/sandbox/${this.instanceId}/fs/watch?path=${encodeURIComponent(path)}&recursive=true`;
+    let socket: WebSocket | null = null;
+    let closed = false;
+
+    const connect = () => {
+      if (closed) return;
+      socket = new WebSocket(url);
+      socket.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(typeof event.data === "string" ? event.data : "{}");
+          if (msg && msg.type && msg.path) {
+            cb({
+              type: msg.type,
+              path: msg.path,
+              fromPath: msg.from_path ?? msg.fromPath,
+            });
+          }
+        } catch {
+          // Ignore malformed frames — daemon should only send JSON.
+        }
+      };
+      socket.onclose = () => {
+        if (closed) return;
+        // Light reconnect backoff — most disconnects are sandbox restarts.
+        setTimeout(connect, 1500);
+      };
+      socket.onerror = () => {
+        socket?.close();
+      };
+    };
+    connect();
+
+    return () => {
+      closed = true;
+      socket?.close();
+    };
+  }
+
+  // ── search ─────────────────────────────────────────────────────────────────
+
+  async searchContent(opts: {
+    query: string;
+    regex?: boolean;
+    caseSensitive?: boolean;
+    includeGlobs?: string[];
+    excludeGlobs?: string[];
+    maxResults?: number;
+    onHit: (hit: FilesystemSearchHit) => void;
+    signal?: AbortSignal;
+  }): Promise<{ truncated: boolean }> {
+    const resp = await fetch(`/api/sandbox/${this.instanceId}/search/content`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: opts.query,
+        regex: opts.regex ?? false,
+        case_sensitive: opts.caseSensitive ?? false,
+        include_globs: opts.includeGlobs,
+        exclude_globs: opts.excludeGlobs,
+        max_results: opts.maxResults ?? 1000,
+      }),
+      signal: opts.signal,
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`search/content failed (${resp.status}): ${text}`);
+    }
+    const data = await resp.json();
+    for (const hit of data.matches ?? []) {
+      opts.onHit({
+        path: hit.path,
+        line: hit.line,
+        column: hit.column,
+        text: (hit.text ?? "").trim(),
+      });
+    }
+    return { truncated: !!data.truncated };
+  }
+
+  async searchPaths(opts: {
+    pattern: string;
+    fuzzy?: boolean;
+    maxResults?: number;
+  }): Promise<string[]> {
+    const resp = await fetch(`/api/sandbox/${this.instanceId}/search/paths`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        pattern: opts.pattern,
+        fuzzy: opts.fuzzy ?? false,
+        max_results: opts.maxResults ?? 200,
+      }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText);
+      throw new Error(`search/paths failed (${resp.status}): ${text}`);
+    }
+    const data = await resp.json();
+    return (data.paths ?? []) as string[];
   }
 }

--- a/features/code/adapters/SandboxGitAdapter.ts
+++ b/features/code/adapters/SandboxGitAdapter.ts
@@ -1,0 +1,206 @@
+/**
+ * Adapter for git operations against a sandbox.
+ *
+ * All methods route through /api/sandbox/[id]/git/* which proxies to the
+ * orchestrator and from there into the in-container daemon (which shells out
+ * to `git`). The point of having a structured adapter — rather than calling
+ * `process.exec("git status")` — is that the responses are already parsed
+ * JSON, so the source-control UI never has to scrape `git` output.
+ *
+ * The interface intentionally mirrors the matrx_agent daemon's contract one
+ * to one. See `/srv/projects/matrx-sandbox/SANDBOX_CLIENT_GUIDE.md` §8 for
+ * the underlying semantics.
+ */
+
+import type { SandboxAccessResponse } from "@/types/sandbox";
+
+// `cwd` is repeated on every call because the daemon scopes git operations to
+// a directory inside the sandbox. Defaults to /home/agent.
+type WithCwd<T = Record<string, never>> = T & { cwd?: string };
+
+export interface GitFileChange {
+    path: string;
+    status: string; // "M", "A", "D", "??", etc. — matches `git status --porcelain` codes
+}
+
+export interface GitStatusResponse {
+    branch: string;
+    ahead: number;
+    behind: number;
+    staged: GitFileChange[];
+    unstaged: GitFileChange[];
+    untracked: string[];
+    conflicted: string[];
+}
+
+export interface GitLogEntry {
+    sha: string;
+    short: string;
+    author: string;
+    date: string;
+    subject: string;
+}
+
+export interface GitDiff {
+    path: string | null;
+    /** Unified diff text. */
+    text: string;
+    staged: boolean;
+}
+
+export interface GitCloneRequest {
+    url: string;
+    dest: string;
+    branch?: string;
+    depth?: number;
+    /** Reference into the credential store; opaque to the frontend. */
+    credentials_ref?: string;
+}
+
+export interface GitCommitRequest {
+    message: string;
+    author?: { name: string; email: string };
+    amend?: boolean;
+}
+
+export interface GitBranchAction {
+    action: "create" | "delete" | "switch";
+    name: string;
+}
+
+export interface GitStashAction {
+    action: "push" | "pop" | "list" | "drop";
+    message?: string;
+}
+
+export interface GitAdapterOptions {
+    /** sandbox_instances.id (the UUID used by the /api/sandbox/[id] route). */
+    instanceId: string;
+}
+
+export class SandboxGitAdapter {
+    readonly id: string;
+    constructor(public readonly opts: GitAdapterOptions) {
+        this.id = `sandbox-git:${opts.instanceId}`;
+    }
+
+    private async post<T>(path: string, body: unknown): Promise<T> {
+        const resp = await fetch(`/api/sandbox/${this.opts.instanceId}/git/${path}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        });
+        if (!resp.ok) {
+            const txt = await resp.text().catch(() => resp.statusText);
+            throw new Error(`git ${path} failed (${resp.status}): ${txt}`);
+        }
+        return resp.json();
+    }
+
+    private async get<T>(path: string, query?: Record<string, string | undefined>): Promise<T> {
+        const qs = query
+            ? "?" +
+              Object.entries(query)
+                  .filter(([, v]) => v !== undefined && v !== "")
+                  .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v as string)}`)
+                  .join("&")
+            : "";
+        const resp = await fetch(`/api/sandbox/${this.opts.instanceId}/git/${path}${qs}`);
+        if (!resp.ok) {
+            const txt = await resp.text().catch(() => resp.statusText);
+            throw new Error(`git ${path} failed (${resp.status}): ${txt}`);
+        }
+        return resp.json();
+    }
+
+    // ── Repo lifecycle ─────────────────────────────────────────────────────
+
+    clone(req: GitCloneRequest): Promise<{ ok: boolean; path: string }> {
+        return this.post("clone", req);
+    }
+
+    // ── Read ───────────────────────────────────────────────────────────────
+
+    status(opts?: WithCwd): Promise<GitStatusResponse> {
+        return this.get("status", { cwd: opts?.cwd });
+    }
+
+    diff(opts?: WithCwd<{ path?: string; staged?: boolean }>): Promise<GitDiff> {
+        return this.get("diff", {
+            cwd: opts?.cwd,
+            path: opts?.path,
+            staged: opts?.staged ? "true" : undefined,
+        });
+    }
+
+    log(opts?: WithCwd<{ limit?: number }>): Promise<GitLogEntry[]> {
+        return this.get("log", {
+            cwd: opts?.cwd,
+            limit: opts?.limit ? String(opts.limit) : undefined,
+        });
+    }
+
+    // ── Mutate ─────────────────────────────────────────────────────────────
+
+    add(opts: WithCwd<{ paths: string[] }>): Promise<{ ok: boolean }> {
+        return this.post("add", opts);
+    }
+
+    commit(opts: WithCwd<GitCommitRequest>): Promise<{ sha: string }> {
+        return this.post("commit", opts);
+    }
+
+    push(opts: WithCwd<{ remote?: string; branch?: string; force_with_lease?: boolean }> = {}): Promise<{ ok: boolean }> {
+        return this.post("push", opts);
+    }
+
+    pull(opts: WithCwd<{ remote?: string; branch?: string; rebase?: boolean }> = {}): Promise<{ ok: boolean }> {
+        return this.post("pull", opts);
+    }
+
+    branch(opts: WithCwd<GitBranchAction>): Promise<{ ok: boolean }> {
+        return this.post("branch", opts);
+    }
+
+    stash(opts: WithCwd<GitStashAction>): Promise<{ ok: boolean; entries?: string[] }> {
+        return this.post("stash", opts);
+    }
+
+    // ── Credentials ────────────────────────────────────────────────────────
+    // Note: credentials are NOT a /git endpoint — they live at
+    // /api/sandbox/[id]/credentials. We expose them here so a "Source Control"
+    // UI has a single object to reach for.
+
+    setGithubToken(token: string, scope: "read" | "write" = "write"): Promise<{ ok: boolean }> {
+        return this.postCredentials({ kind: "github", token, scope });
+    }
+
+    setSshKey(privateKey: string, knownHosts?: string): Promise<{ ok: boolean }> {
+        return this.postCredentials({ kind: "ssh", private_key: privateKey, known_hosts: knownHosts });
+    }
+
+    revokeCredentials(): Promise<{ ok: boolean }> {
+        return fetch(`/api/sandbox/${this.opts.instanceId}/credentials/revoke`, {
+            method: "POST",
+        }).then((r) => {
+            if (!r.ok) throw new Error(`revoke failed (${r.status})`);
+            return r.json();
+        });
+    }
+
+    private async postCredentials<T>(body: Record<string, unknown>): Promise<T> {
+        const resp = await fetch(`/api/sandbox/${this.opts.instanceId}/credentials`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        });
+        if (!resp.ok) {
+            const txt = await resp.text().catch(() => resp.statusText);
+            throw new Error(`credentials failed (${resp.status}): ${txt}`);
+        }
+        return resp.json();
+    }
+}
+
+// Re-export the SSH access helper near the git adapter — natural neighbor.
+export type { SandboxAccessResponse };

--- a/features/code/adapters/SandboxProcessAdapter.ts
+++ b/features/code/adapters/SandboxProcessAdapter.ts
@@ -1,5 +1,5 @@
 import type { ProcessAdapter } from "./ProcessAdapter";
-import type { ProcessResult } from "../types";
+import type { ProcessEvent, ProcessResult } from "../types";
 
 /** Matches the response shape of /api/sandbox/[id]/exec */
 interface RawExecResponse {
@@ -34,17 +34,20 @@ export class SandboxProcessAdapter implements ProcessAdapter {
 
   async exec(
     command: string,
-    opts?: { cwd?: string; timeoutSec?: number },
+    opts?: {
+      cwd?: string;
+      timeoutSec?: number;
+      env?: Record<string, string>;
+      stdin?: string;
+    },
   ): Promise<ProcessResult> {
     const body: Record<string, unknown> = {
       command,
       timeout: opts?.timeoutSec ?? 60,
     };
-    // Only forward an explicit cwd override to the orchestrator when the
-    // caller asked for one. Otherwise let the orchestrator use whatever
-    // working directory its session is already in — that way `cd` persists
-    // naturally between exec calls.
     if (opts?.cwd) body.cwd = opts.cwd;
+    if (opts?.env) body.env = opts.env;
+    if (opts?.stdin !== undefined) body.stdin = opts.stdin;
 
     const resp = await fetch(`/api/sandbox/${this.instanceId}/exec`, {
       method: "POST",
@@ -64,6 +67,104 @@ export class SandboxProcessAdapter implements ProcessAdapter {
       exitCode: data.exit_code ?? 0,
       cwd: this.cwd,
     };
+  }
+
+  /**
+   * Streaming exec via SSE. Stdout/stderr arrive incrementally via `onEvent`;
+   * the returned ProcessResult resolves when the orchestrator emits the `exit`
+   * event. Aborting the AbortSignal closes the SSE connection — the
+   * orchestrator interprets that as cancellation and SIGTERMs the command.
+   */
+  async stream(
+    command: string,
+    onEvent: (ev: ProcessEvent) => void,
+    opts?: {
+      cwd?: string;
+      env?: Record<string, string>;
+      stdin?: string;
+      signal?: AbortSignal;
+    },
+  ): Promise<ProcessResult> {
+    const body: Record<string, unknown> = { command };
+    if (opts?.cwd) body.cwd = opts.cwd;
+    if (opts?.env) body.env = opts.env;
+    if (opts?.stdin !== undefined) body.stdin = opts.stdin;
+
+    const resp = await fetch(`/api/sandbox/${this.instanceId}/exec/stream`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
+      body: JSON.stringify(body),
+      signal: opts?.signal,
+    });
+    if (!resp.ok || !resp.body) {
+      const errBody = await resp.text().catch(() => resp.statusText);
+      throw new Error(`exec/stream failed (${resp.status}): ${errBody}`);
+    }
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let exitCode = 0;
+    let stdout = "";
+    let stderr = "";
+    let cwd = this.cwd;
+
+    // Robust SSE parsing — the standard says events are separated by blank
+    // lines; data lines start with "data: ". Multi-line data values are joined
+    // with "\n".
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // Drain complete events (terminated by a blank line) from the buffer.
+      let idx: number;
+      while ((idx = buffer.indexOf("\n\n")) >= 0) {
+        const rawEvent = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        if (!rawEvent.trim()) continue;
+
+        let eventName = "message";
+        const dataLines: string[] = [];
+        for (const line of rawEvent.split("\n")) {
+          if (line.startsWith("event:")) eventName = line.slice(6).trim();
+          else if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+        }
+        if (!dataLines.length) continue;
+
+        let payload: Record<string, unknown> = {};
+        try {
+          payload = JSON.parse(dataLines.join("\n"));
+        } catch {
+          // Some daemons emit raw text — wrap as text payload so we don't lose it.
+          payload = { data: dataLines.join("\n") };
+        }
+
+        if (eventName === "stdout") {
+          const text = String(payload.data ?? "");
+          stdout += text;
+          onEvent({ type: "stdout", text });
+        } else if (eventName === "stderr") {
+          const text = String(payload.data ?? "");
+          stderr += text;
+          onEvent({ type: "stderr", text });
+        } else if (eventName === "exit") {
+          exitCode = Number(payload.exit_code ?? 0);
+          if (typeof payload.cwd === "string") cwd = payload.cwd;
+          onEvent({
+            type: "exit",
+            text: "",
+            exitCode,
+            cwd,
+          });
+        } else {
+          onEvent({ type: "info", text: String(payload.data ?? "") });
+        }
+      }
+    }
+
+    if (cwd) this.cwd = cwd;
+    return { stdout, stderr, exitCode, cwd };
   }
 }
 

--- a/features/code/types.ts
+++ b/features/code/types.ts
@@ -23,8 +23,33 @@ export interface FilesystemNode {
 }
 
 export interface FilesystemWatchEvent {
-  type: "created" | "modified" | "deleted";
+  type: "created" | "modified" | "deleted" | "moved";
   path: string;
+  /** Present for "moved" events — the original path before the rename. */
+  fromPath?: string;
+}
+
+export interface FilesystemStat {
+  path: string;
+  kind: FilesystemNodeKind | "symlink";
+  size: number;
+  /** Unix mode bits (e.g. 0o644). */
+  mode?: number;
+  /** ISO date string. */
+  modifiedAt?: string;
+  /** sha1 of contents — when the adapter cheaply provides it. */
+  hash?: string;
+  /** Symlink target, if `kind === "symlink"`. */
+  target?: string;
+}
+
+export interface FilesystemSearchHit {
+  path: string;
+  /** 1-based line number of the match. */
+  line: number;
+  column?: number;
+  /** The matched line contents (trimmed). */
+  text: string;
 }
 
 // ─── Editor files / tabs ─────────────────────────────────────────────────────

--- a/hooks/sandbox/use-sandbox-heartbeat.ts
+++ b/hooks/sandbox/use-sandbox-heartbeat.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Pings the sandbox orchestrator's heartbeat endpoint at a fixed interval
+ * while the hook is mounted with a non-empty `sandboxRowId`.
+ *
+ * Use case: the editor mounts this once per active session so the orchestrator's
+ * idle-shutdown sweep doesn't reap a sandbox the user is actively working in.
+ * The heartbeat is *not* a TTL extension — see `useSandboxExtend` (or the
+ * direct `POST /api/sandbox/[id]/extend` route) when you need to push the
+ * expiry forward.
+ *
+ * Cheap: a single 200-byte POST per minute. Aborted on unmount.
+ */
+export function useSandboxHeartbeat(
+    sandboxRowId: string | null | undefined,
+    options?: { intervalMs?: number; enabled?: boolean }
+) {
+    const intervalMs = options?.intervalMs ?? 60_000;
+    const enabled = options?.enabled ?? true;
+    const lastErrorRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!enabled || !sandboxRowId) return;
+
+        const controller = new AbortController();
+        let timer: ReturnType<typeof setInterval> | null = null;
+
+        const beat = async () => {
+            try {
+                const resp = await fetch(`/api/sandbox/${sandboxRowId}/heartbeat`, {
+                    method: "POST",
+                    signal: controller.signal,
+                });
+                if (!resp.ok) {
+                    const text = await resp.text().catch(() => resp.statusText);
+                    lastErrorRef.current = text;
+                    if (process.env.NODE_ENV === "development") {
+                        console.warn(`[sandbox heartbeat] ${resp.status}: ${text}`);
+                    }
+                } else {
+                    lastErrorRef.current = null;
+                }
+            } catch (err) {
+                if ((err as Error)?.name === "AbortError") return;
+                lastErrorRef.current = (err as Error)?.message ?? "unknown error";
+                if (process.env.NODE_ENV === "development") {
+                    console.warn(`[sandbox heartbeat] ${lastErrorRef.current}`);
+                }
+            }
+        };
+
+        // Fire one immediately, then on the cadence.
+        void beat();
+        timer = setInterval(beat, intervalMs);
+
+        return () => {
+            controller.abort();
+            if (timer) clearInterval(timer);
+        };
+    }, [sandboxRowId, intervalMs, enabled]);
+
+    return { lastError: lastErrorRef.current };
+}

--- a/lib/sandbox/orchestrator-routing.ts
+++ b/lib/sandbox/orchestrator-routing.ts
@@ -1,0 +1,100 @@
+/**
+ * Orchestrator URL/key resolution for the two-tier sandbox model.
+ *
+ * Each sandbox is hosted on exactly one orchestrator (EC2 or hosted on the
+ * Matrx dev server). The tier is captured at create time and persisted in the
+ * sandbox row's `config.tier` field. Every per-sandbox proxy route (`/exec`,
+ * `/fs/*`, `/git/*`, `/extend`, …) reads the row, resolves the tier, and
+ * forwards to the matching orchestrator URL with the matching API key.
+ *
+ * This is a server-only module — never import from a Client Component.
+ */
+
+import { createClient } from '@/utils/supabase/server'
+import type { SandboxConfig, SandboxTier } from '@/types/sandbox'
+
+const EC2_URL = process.env.MATRX_ORCHESTRATOR_URL || 'http://54.144.86.132:8000'
+const EC2_KEY = process.env.MATRX_ORCHESTRATOR_API_KEY || ''
+const HOSTED_URL = process.env.MATRX_HOSTED_ORCHESTRATOR_URL || 'https://orchestrator.dev.codematrx.com'
+const HOSTED_KEY = process.env.MATRX_HOSTED_ORCHESTRATOR_API_KEY || ''
+
+export interface OrchestratorTarget {
+    /** Base URL, no trailing slash. */
+    url: string
+    /** API key (sent as `X-API-Key`). May be empty for local dev. */
+    apiKey: string
+    /** Resolved tier — either explicit or 'ec2' (back-compat default). */
+    tier: SandboxTier
+}
+
+/**
+ * Resolve which orchestrator to forward a request to based on a sandbox's
+ * persisted tier. Rows without an explicit tier default to EC2 — that
+ * preserves behavior for sandboxes created before the tier model existed.
+ */
+export function resolveOrchestratorByTier(tier: SandboxTier | null | undefined): OrchestratorTarget {
+    if (tier === 'hosted') {
+        return { url: HOSTED_URL.replace(/\/$/, ''), apiKey: HOSTED_KEY, tier: 'hosted' }
+    }
+    return { url: EC2_URL.replace(/\/$/, ''), apiKey: EC2_KEY, tier: 'ec2' }
+}
+
+/**
+ * Look up a sandbox by its row id (the Postgres UUID, not the orchestrator's
+ * `sandbox_id`), enforce ownership against the current Supabase user, and
+ * resolve its orchestrator target plus the upstream `sandbox_id`.
+ *
+ * Returns `null` for the orchestrator field on errors so callers can build a
+ * single response without a try/catch chain.
+ */
+export async function lookupSandboxAndOrchestrator(
+    sandboxRowId: string
+): Promise<
+    | {
+          ok: true
+          orchestrator: OrchestratorTarget
+          sandboxId: string
+          status: string
+      }
+    | { ok: false; status: number; error: string }
+> {
+    const supabase = await createClient()
+    const {
+        data: { user },
+        error: userError,
+    } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+        return { ok: false, status: 401, error: 'User not authenticated' }
+    }
+
+    const { data, error } = await supabase
+        .from('sandbox_instances')
+        .select('sandbox_id, status, config')
+        .eq('id', sandboxRowId)
+        .eq('user_id', user.id)
+        .is('deleted_at', null)
+        .single()
+
+    if (error || !data) {
+        return { ok: false, status: 404, error: 'Sandbox instance not found' }
+    }
+
+    const tier = ((data.config as SandboxConfig | null)?.tier ?? null) as SandboxTier | null
+    return {
+        ok: true,
+        orchestrator: resolveOrchestratorByTier(tier),
+        sandboxId: data.sandbox_id,
+        status: data.status,
+    }
+}
+
+/**
+ * Build the standard headers we send to the orchestrator on JSON calls.
+ * Caller can spread additional headers on top.
+ */
+export function orchestratorJsonHeaders(target: OrchestratorTarget): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (target.apiKey) headers['X-API-Key'] = target.apiKey
+    return headers
+}

--- a/lib/sandbox/proxy-helpers.ts
+++ b/lib/sandbox/proxy-helpers.ts
@@ -1,0 +1,115 @@
+/**
+ * Generic helpers for forwarding sandbox API requests from the Next.js layer
+ * to the orchestrator. Each per-sandbox proxy route (fs, git, search, …)
+ * does the same thing: auth-check → look up the sandbox → forward the request
+ * to the right orchestrator URL → stream the response back.
+ *
+ * These helpers centralize that pattern so individual route handlers stay
+ * thin (auth + URL construction + a one-line `forwardJson` or `forwardStream`).
+ *
+ * Server-only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import {
+    lookupSandboxAndOrchestrator,
+    type OrchestratorTarget,
+} from '@/lib/sandbox/orchestrator-routing'
+
+const HOP_BY_HOP_HEADERS = new Set([
+    'host',
+    'content-length',
+    'connection',
+    'transfer-encoding',
+    'keep-alive',
+    'cookie',
+    // We add x-api-key ourselves
+    'x-api-key',
+    'authorization',
+])
+
+function buildUpstreamHeaders(
+    request: NextRequest,
+    target: OrchestratorTarget
+): Headers {
+    const headers = new Headers()
+    request.headers.forEach((value, key) => {
+        if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+            headers.set(key, value)
+        }
+    })
+    if (target.apiKey) headers.set('X-API-Key', target.apiKey)
+    return headers
+}
+
+/**
+ * Forward a request to the orchestrator and stream the upstream response back
+ * to the caller. Works for both regular JSON and SSE/streaming bodies.
+ *
+ * `upstreamUrl` is built by the route handler (it knows the path shape).
+ * The forwarded request preserves method, body, and most headers (minus
+ * hop-by-hop ones).
+ */
+export async function forwardToOrchestrator(
+    request: NextRequest,
+    upstreamUrl: string,
+    target: OrchestratorTarget,
+    options: { stream?: boolean; timeoutMs?: number } = {}
+): Promise<Response> {
+    const init: RequestInit = {
+        method: request.method,
+        headers: buildUpstreamHeaders(request, target),
+    }
+
+    // Body for non-GET/HEAD. Streaming bodies (e.g. multipart upload) need
+    // duplex: 'half' on the fetch init to opt into streaming.
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+        init.body = request.body
+        // @ts-expect-error — duplex is required by Node's undici when streaming a body
+        init.duplex = 'half'
+    }
+
+    if (options.timeoutMs) {
+        init.signal = AbortSignal.timeout(options.timeoutMs)
+    }
+
+    try {
+        const upstream = await fetch(upstreamUrl, init)
+
+        // Filter out hop-by-hop response headers
+        const responseHeaders = new Headers()
+        upstream.headers.forEach((value, key) => {
+            if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+                responseHeaders.set(key, value)
+            }
+        })
+
+        return new Response(upstream.body, {
+            status: upstream.status,
+            statusText: upstream.statusText,
+            headers: responseHeaders,
+        })
+    } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error'
+        return NextResponse.json(
+            { error: 'Sandbox orchestrator is not reachable', details: message },
+            { status: 502 }
+        )
+    }
+}
+
+/**
+ * Standard preamble for a per-sandbox proxy route: resolves the orchestrator
+ * target by tier, returns either an early error response or a typed object
+ * the handler can use to call `forwardToOrchestrator`.
+ */
+export async function resolveProxyContext(sandboxRowId: string) {
+    const lookup = await lookupSandboxAndOrchestrator(sandboxRowId)
+    if (!lookup.ok) {
+        return {
+            ok: false as const,
+            response: NextResponse.json({ error: lookup.error }, { status: lookup.status }),
+        }
+    }
+    return { ok: true as const, ...lookup }
+}

--- a/types/sandbox.ts
+++ b/types/sandbox.ts
@@ -15,6 +15,23 @@ export type SandboxStopReason =
     | 'graceful_shutdown'
     | 'admin'
 
+export type SandboxTier = 'ec2' | 'hosted'
+
+/**
+ * Per-sandbox config slot. Free-form JSON. The frontend stuffs `tier` + `template`
+ * + `template_version` + `resources` + `labels` here when no dedicated columns
+ * exist (db migration to promote them is a follow-up). The orchestrator reads
+ * the same payload back via `config` on `SandboxResponse`.
+ */
+export interface SandboxConfig {
+    tier?: SandboxTier
+    template?: string
+    template_version?: string
+    resources?: { cpu?: number; memory_mb?: number; disk_mb?: number }
+    labels?: Record<string, string>
+    [extraKey: string]: unknown
+}
+
 export interface SandboxInstance {
     id: string
     user_id: string
@@ -24,7 +41,7 @@ export interface SandboxInstance {
     container_id: string | null
     hot_path: string
     cold_path: string
-    config: Record<string, unknown>
+    config: SandboxConfig
     ttl_seconds: number
     expires_at: string | null
     last_heartbeat_at: string | null
@@ -54,6 +71,10 @@ export interface SandboxExecRequest {
     command: string
     timeout?: number
     cwd?: string
+    /** Additional env vars merged into the sandbox default env for this single call. */
+    env?: Record<string, string>
+    /** Optional stdin payload — bypasses the 10K command-length cap. */
+    stdin?: string
 }
 
 export interface SandboxExecResponse {
@@ -65,8 +86,16 @@ export interface SandboxExecResponse {
 
 export interface SandboxCreateRequest {
     project_id?: string
-    config?: Record<string, unknown>
+    config?: SandboxConfig
     ttl_seconds?: number
+    /** Tier picker — 'ec2' (ephemeral, S3-backed) or 'hosted' (this server, larger workloads). */
+    tier?: SandboxTier
+    /** Template id; see `GET /api/templates`. */
+    template?: string
+    template_version?: string
+    /** Resource overrides (hosted tier only). */
+    resources?: { cpu?: number; memory_mb?: number; disk_mb?: number }
+    labels?: Record<string, string>
 }
 
 export type SandboxAction = 'stop' | 'extend'
@@ -74,6 +103,26 @@ export type SandboxAction = 'stop' | 'extend'
 export interface SandboxActionRequest {
     action: SandboxAction
     ttl_seconds?: number
+}
+
+export interface SandboxExtendResponse {
+    sandbox_id: string
+    ttl_seconds: number
+    expires_at: string
+    new_expires_at: string
+}
+
+export interface SandboxTemplate {
+    id: string
+    version: string
+    description: string
+    image: string
+    tier: SandboxTier | null
+    languages: string[]
+}
+
+export interface SandboxTemplateListResponse {
+    templates: SandboxTemplate[]
 }
 
 export interface SandboxAccessResponse {


### PR DESCRIPTION
## Summary

Wires the `/code` editor up to the wishlist surface that the orchestrator's `matrx_agent` daemon already implements (filesystem proxy, streaming exec, git, credentials, search, processes, ports, file watcher), plus the new tier-aware routing for the EC2 orchestrator and the new self-hosted orchestrator at `https://orchestrator.dev.codematrx.com`.

The `/code` team's earlier audit (`features/code/SYSTEM_STATE.md` §3) said only 8 endpoints existed on the orchestrator. **The audit was correct about the prod EC2 deploy**, but for a different reason than assumed: the orchestrator code on disk *did* implement everything, the EC2 deploy was just stuck at v0.1.0 since Feb because the deploy pipeline was misconfigured (it built/pushed Docker images that the orchestrator never actually used). That's been fixed in matrx-sandbox; both tiers now run v0.2.0+.

## What's in this PR

**Backend (Next.js proxy routes)**
- `lib/sandbox/orchestrator-routing.ts` — resolves `{url, key, tier}` per sandbox.
- `lib/sandbox/proxy-helpers.ts` — shared forward/auth helpers.
- 13 new proxy routes under `app/api/sandbox/[id]/{fs,git,search}/[...path]`, `app/api/sandbox/[id]/{credentials, credentials/revoke, processes, processes/[pid]/signal, ports, exec/stream, heartbeat, extend}`, plus `app/api/templates`.
- `POST /api/sandbox` now accepts `tier`/`template`/`template_version`/`resources`/`labels`, routes to the right orchestrator, persists `tier` in `sandbox_instances.config`.
- `PUT /api/sandbox/[id]` `action: "extend"` now actually calls the orchestrator and mirrors the new `expires_at` (was DB-only and silently drifted).
- `/api/sandbox/[id]/{exec,access}` are tier-aware via `lookupSandboxAndOrchestrator`.

**Adapters**
- `FilesystemAdapter` — added `stat`, `mkdir`, `rename`, `delete`, `copy`, `readFileBinary`, `writeFileBinary`, `searchContent`, `searchPaths`, `watch`.
- `SandboxFilesystemAdapter` — full rewrite. All shell synthesis (`ls`/`cat`/`base64 -d`) gone. Backed by `/api/sandbox/[id]/fs/*` + `/search/*` + WS `/fs/watch`. Binary-safe.
- `ProcessAdapter` — `exec` gains `env`/`stdin` opts; `stream(...)` is now part of the contract.
- `SandboxProcessAdapter` — SSE-parsed `stream()` against `/exec/stream`.
- `SandboxGitAdapter` — new. clone/status/diff/log/add/commit/push/pull/branch/stash + `setGithubToken` / `setSshKey` / `revokeCredentials`.

**Hooks**
- `useSandboxHeartbeat(sandboxRowId)` — 60s ping so the orchestrator's idle-shutdown sweep doesn't reap the sandbox during an active editor session.

**Types**
- `SandboxConfig`, `SandboxTier`, `SandboxTemplate`, `ResourcesSpec`, `SandboxExtendResponse`, `FilesystemStat`, `FilesystemSearchHit`; `FilesystemWatchEvent` + `'moved'` event type.

**Docs**
- `features/code/SYSTEM_STATE.md` §3 corrected with the verified state. Use `GET /api-surface` for capability discovery — `/openapi.json` omits catchall proxy routes.

## Two-tier model

| Tier | URL | Backed by | Best for |
|---|---|---|---|
| `ec2` | `http://54.144.86.132:8000` | EC2 + S3 hot/cold + Supabase Postgres | Ephemeral agent runs, quick tasks |
| `hosted` | `https://orchestrator.dev.codematrx.com` | Matrx dev server + Docker volumes | Long-lived editor sessions, larger workloads, internal-network access |

Tier is captured at create time and persisted on the `sandbox_instances` row in `config.tier`. Every per-sandbox proxy route resolves the orchestrator from the row, so list/exec/fs/git/extend all "just work" regardless of tier. Rows without an explicit tier default to EC2 (back-compat for sandboxes created before this change).

## Required env vars (Vercel)

Existing (no change):
- `MATRX_ORCHESTRATOR_URL`, `MATRX_ORCHESTRATOR_API_KEY` — EC2 tier.

New:
- `MATRX_HOSTED_ORCHESTRATOR_URL` — defaults to `https://orchestrator.dev.codematrx.com`.
- `MATRX_HOSTED_ORCHESTRATOR_API_KEY` — recorded in `/srv/.credentials` on the dev server as `SANDBOX_ORCHESTRATOR_HOSTED_API_KEY`.

## Deferred to follow-up PRs (backend ready)

- `TerminalTab` PTY rewrite — WS `/pty` proxy route is live; the editor terminal still does one-shot exec.
- Tier picker dropdown in `SandboxesPanel` — backend accepts the fields; needs UI.
- Bulk fs upload/download adapter helpers.
- Source Control activity-bar view backed by `SandboxGitAdapter`.

## Test plan

- [ ] Create an EC2-tier sandbox via the existing flow → it gets `config.tier = "ec2"` (default).
- [ ] Create a hosted-tier sandbox via `POST /api/sandbox { tier: "hosted", template: "node-22" }` → routes to `orchestrator.dev.codematrx.com` and returns a sandbox.
- [ ] Save a 1MB binary via the new `SandboxFilesystemAdapter.writeFileBinary` → read back identical (sha256 match).
- [ ] Stream a long command through `SandboxProcessAdapter.stream()` → output streams; AbortSignal cancels.
- [ ] `PUT /api/sandbox/[id] { action: "extend", ttl_seconds: 7200 }` → orchestrator returns new `expires_at`; DB row mirrors it.
- [ ] `useSandboxHeartbeat` mounts → `last_heartbeat_at` advances every 60s.
- [ ] `/api/templates?tier=hosted` returns the three templates from the hosted orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds many new sandbox proxy endpoints (fs/git/search/streaming exec/credentials/process control) and changes sandbox create/extend/exec routing logic, which can impact auth/ownership enforcement and runtime behavior across two orchestrators.
> 
> **Overview**
> Enables **two-tier sandbox routing** by introducing `lookupSandboxAndOrchestrator`/`resolveOrchestratorByTier` and updating sandbox routes to forward requests to the correct orchestrator (EC2 vs hosted) with per-tier API keys.
> 
> Expands the Next.js sandbox API into a **rich proxy surface**: adds catchall proxies for `fs`, `git`, and `search`, plus new endpoints for `exec` streaming (SSE), credentials set/revoke, heartbeat, extend, ports, and process listing/signal.
> 
> Updates sandbox lifecycle calls to be **orchestrator-authoritative**: `POST /api/sandbox` now accepts `tier`/`template`/`resources`/`labels` and persists tier in `config`; TTL extension now calls the orchestrator and mirrors `expires_at` back into Postgres (with a new `POST /api/sandbox/[id]/extend` and back-compat `PUT action=extend`).
> 
> Reworks `/code` adapters to consume the new surface: `SandboxFilesystemAdapter` switches from shelling via `/exec` to the structured `/fs` API (binary-safe, mkdir/rename/copy/delete, watch), `SandboxProcessAdapter` adds `env`/`stdin` and SSE `stream()`, and a new `SandboxGitAdapter` adds structured git + credential management; types/docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 282e325a944867d3275ad772d7054273a498c18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->