### PR TITLE
feat: wire /images route tree (manager, search, studio)

### DIFF
--- a/app/(a)/image-manager/page.tsx
+++ b/app/(a)/image-manager/page.tsx
@@ -1,15 +1,5 @@
-/**
- * app/(a)/image-manager/page.tsx
- *
- * Server Component entry. The shell itself is interactive (Redux,
- * tab switching, file selection) so it lives in a Client Component
- * sibling. We render the shell directly here — no data fetching at
- * this level; the layout already mounts the realtime provider that
- * hydrates the slice client-side.
- */
-
-import { ImageManagerPageShell } from "./_components/ImageManagerPageShell";
+import { redirect } from "next/navigation";
 
 export default function ImageManagerPage() {
-  return <ImageManagerPageShell />;
+  redirect("/images/manager");
 }

--- a/app/(a)/image-studio/page.tsx
+++ b/app/(a)/image-studio/page.tsx
@@ -1,16 +1,5 @@
-import { StudioLandingHero } from "@/features/image-studio/components/StudioLandingHero";
+import { redirect } from "next/navigation";
 
-/**
- * Image Studio landing page.
- *
- * Pure Server Component — entirely static, no client JS shipped for the
- * hero, feature grid, preset-category legend, or workflow walkthrough.
- * Interactivity lives in the sub-routes (/convert, /presets, /library).
- */
-export default function ImageStudioLanding() {
-    return (
-        <main className="min-h-[calc(100dvh-2.5rem)] overflow-y-auto bg-background">
-            <StudioLandingHero />
-        </main>
-    );
+export default function ImageStudioPage() {
+  redirect("/images/studio");
 }

--- a/app/(a)/images/manager/layout.tsx
+++ b/app/(a)/images/manager/layout.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { createClient } from "@/utils/supabase/server";
+import { createRouteMetadata } from "@/utils/route-metadata";
+import { CloudFilesRealtimeProvider } from "@/features/files/providers/CloudFilesRealtimeProvider";
+
+export const metadata = createRouteMetadata("/images/manager", {
+  title: "Image Manager",
+  description:
+    "Browse, upload, and create images — every upload lands in your cloud and stays in sync across every Matrx surface.",
+  letter: "Im",
+  additionalMetadata: {
+    keywords: [
+      "image manager",
+      "image picker",
+      "image library",
+      "cloud images",
+      "upload images",
+      "image studio",
+    ],
+  },
+});
+
+export default async function ImagesManagerLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return (
+    <CloudFilesRealtimeProvider userId={user?.id ?? null}>
+      {children}
+    </CloudFilesRealtimeProvider>
+  );
+}

--- a/app/(a)/images/manager/loading.tsx
+++ b/app/(a)/images/manager/loading.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ImagesManagerLoading() {
+  return (
+    <div className="h-[calc(100dvh-var(--header-height))] flex overflow-hidden bg-textured">
+      <aside className="w-44 flex-shrink-0 border-r border-border bg-card/40 flex flex-col">
+        <div className="px-3 py-2.5 border-b border-border">
+          <Skeleton className="h-4 w-28" />
+        </div>
+        <div className="py-1 space-y-0.5 px-2.5">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-2 py-1.5">
+              <Skeleton className="h-3.5 w-3.5 rounded" />
+              <Skeleton className="h-3 flex-1 max-w-[80px]" />
+            </div>
+          ))}
+        </div>
+      </aside>
+
+      <main className="flex-1 min-w-0 flex flex-col overflow-hidden">
+        <header className="border-b border-border bg-card/40 px-5 py-2.5 flex items-center gap-2 flex-shrink-0">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-3.5 w-28" />
+        </header>
+
+        <div className="flex-1 min-h-0 overflow-hidden p-4">
+          <div className="border-b border-border pb-3 flex items-center gap-2">
+            <Skeleton className="h-9 flex-1 max-w-md" />
+            <Skeleton className="h-8 w-20" />
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-4">
+            {Array.from({ length: 10 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-square rounded-md" />
+            ))}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(a)/images/manager/page.tsx
+++ b/app/(a)/images/manager/page.tsx
@@ -1,0 +1,5 @@
+import { ImageManagerPageShell } from "@/app/(a)/image-manager/_components/ImageManagerPageShell";
+
+export default function ImagesManagerPage() {
+  return <ImageManagerPageShell />;
+}

--- a/app/(a)/images/page.tsx
+++ b/app/(a)/images/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function ImagesPage() {
+  redirect("/images/manager");
+}

--- a/app/(a)/images/search/_components/SearchPageShell.tsx
+++ b/app/(a)/images/search/_components/SearchPageShell.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { BrowseImageProvider } from "@/features/image-manager/browse/BrowseImageProvider";
+import { PublicImagesSection } from "@/features/image-manager/components/PublicImagesSection";
+
+export function SearchPageShell() {
+  return (
+    <BrowseImageProvider>
+      <div className="h-[calc(100dvh-var(--header-height))] overflow-hidden bg-textured">
+        <PublicImagesSection />
+      </div>
+    </BrowseImageProvider>
+  );
+}

--- a/app/(a)/images/search/layout.tsx
+++ b/app/(a)/images/search/layout.tsx
@@ -1,0 +1,16 @@
+import { createRouteMetadata } from "@/utils/route-metadata";
+import type { ReactNode } from "react";
+
+export const metadata = createRouteMetadata("/images/search", {
+  title: "Image Search",
+  description:
+    "Search millions of public images from Unsplash and browse curated cover collections.",
+  letter: "Is",
+  additionalMetadata: {
+    keywords: ["image search", "unsplash", "public images", "stock photos", "curated covers"],
+  },
+});
+
+export default function ImagesSearchLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/(a)/images/search/page.tsx
+++ b/app/(a)/images/search/page.tsx
@@ -1,0 +1,5 @@
+import { SearchPageShell } from "./_components/SearchPageShell";
+
+export default function ImagesSearchPage() {
+  return <SearchPageShell />;
+}

--- a/app/(a)/images/studio/layout.tsx
+++ b/app/(a)/images/studio/layout.tsx
@@ -1,0 +1,30 @@
+import { createRouteMetadata } from "@/utils/route-metadata";
+import type { ReactNode } from "react";
+
+export const metadata = createRouteMetadata("/images/studio", {
+  title: "Image Studio",
+  description:
+    "Drop one image in, get 60+ platform-perfect sizes out — favicons, Open Graph, social, e-commerce, avatars, logos, print.",
+  letter: "Is",
+  additionalMetadata: {
+    keywords: [
+      "image converter",
+      "favicon generator",
+      "social media image sizes",
+      "open graph image",
+      "image resizer",
+      "avatar generator",
+      "product image sizes",
+      "WebP AVIF JPEG PNG",
+    ],
+  },
+});
+
+export default function ImagesStudioLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <span className="shell-hide-dock" aria-hidden="true" />
+      {children}
+    </>
+  );
+}

--- a/app/(a)/images/studio/page.tsx
+++ b/app/(a)/images/studio/page.tsx
@@ -1,0 +1,9 @@
+import { StudioLandingHero } from "@/features/image-studio/components/StudioLandingHero";
+
+export default function ImagesStudioPage() {
+  return (
+    <main className="min-h-[calc(100dvh-2.5rem)] overflow-y-auto bg-background">
+      <StudioLandingHero />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `/images/manager`, `/images/search`, `/images/studio` as the new canonical image routes
- `/images` (index) redirects to `/images/manager` by default
- `/image-manager` and `/image-studio` top-level pages redirect to their `/images/*` equivalents — no broken links
- Image Studio sub-routes (`/convert`, `/presets`, `/library`, `/from-base64`) remain at existing paths; sub-route migration is a follow-up

## Routes

| New URL | What it renders |
|---|---|
| `/images` | → `/images/manager` |
| `/images/manager` | `ImageManagerPageShell` (10-tab hub) + `CloudFilesRealtimeProvider` |
| `/images/search` | `PublicImagesSection` standalone (Unsplash + curated covers) |
| `/images/studio` | `StudioLandingHero` |
| `/image-manager` | → `/images/manager` |
| `/image-studio` | → `/images/studio` |

## Test plan

- [ ] `/images` redirects to `/images/manager`
- [ ] `/images/manager` renders the full hub with sidebar tabs
- [ ] `/images/search` renders public search + curated covers standalone
- [ ] `/images/studio` renders the studio landing hero
- [ ] `/image-manager` redirects to `/images/manager`
- [ ] `/image-studio` redirects to `/images/studio`
- [ ] Studio sub-routes (`/image-studio/convert` etc.) still work