### PR TITLE
feat: consolidate image upload dropzone

### DIFF
--- a/app/(authenticated)/(admin-auth)/administration/official-components/component-displays/image-asset-uploader.tsx
+++ b/app/(authenticated)/(admin-auth)/administration/official-components/component-displays/image-asset-uploader.tsx
@@ -11,6 +11,7 @@ import {
 import { useOpenImageUploaderWindow } from "@/features/window-panels/windows/image/useOpenImageUploaderWindow";
 import { Button } from "@/components/ui/button";
 import { ExternalLink } from "lucide-react";
+import type { Visibility } from "@/features/files/types";
 
 interface ComponentDisplayProps {
   component?: ComponentEntry;
@@ -54,11 +55,24 @@ const PRESETS: Array<{
   },
 ];
 
+type UploaderMode = "asset" | "cloud";
+type PasteCaptureMode = "auto" | "off" | "cloud" | "asset";
+
 export default function ImageAssetUploaderDisplay({
   component,
 }: ComponentDisplayProps) {
   const [preset, setPreset] = useState<ImagePreset>("social");
+  const [mode, setMode] = useState<UploaderMode>("asset");
+  const [pasteCaptureMode, setPasteCaptureMode] =
+    useState<PasteCaptureMode>("asset");
+  const [visibility, setVisibility] = useState<Visibility>("public");
+  const [allowUrlPaste, setAllowUrlPaste] = useState(true);
+  const [enableViewerAction, setEnableViewerAction] = useState(true);
+  const [compact, setCompact] = useState(false);
+  const [hideVariantBadges, setHideVariantBadges] = useState(false);
+  const [multiple, setMultiple] = useState(false);
   const [result, setResult] = useState<ImageUploaderResult | null>(null);
+  const [uploadedIds, setUploadedIds] = useState<string[]>([]);
   const openWindow = useOpenImageUploaderWindow();
 
   const code = `import { ImageAssetUploader, type ImageUploaderResult } from '@/components/official/ImageAssetUploader';
@@ -66,9 +80,12 @@ import { useOpenImageUploaderWindow } from '@/features/window-panels/windows/ima
 
 // ── Inline (embedded in a form) ──────────────────────────────────────────
 <ImageAssetUploader
+  mode="asset"                      // "asset" | "cloud"
   preset="social"                    // "social" | "cover" | "avatar" | "logo" | "favicon" | "square"
   currentUrl={form.image_url}
   pasteCaptureMode="asset"           // paste clipboard images into the Sharp variant pipeline
+  allowUrlPaste
+  visibility="public"
   enableViewerAction                 // preview opens the shared image window panel
   onComplete={(result) => {
     if (!result) return clear();
@@ -95,6 +112,7 @@ openUploader({
 // Features
 // - Server-side Sharp pipeline: all variants share one original, stay consistent
 // - 6 presets covering every common image shape (social, logo, favicon, …)
+// - mode="cloud" uses the Cloud Files upload pipeline for plain image uploads
 // - Drag-drop, click, clipboard paste, OR paste a public URL
 // - Cloud-files backed uploads with configurable visibility + folder
 // - Optional preview action opens uploaded variants in the shared image panel`;
@@ -120,6 +138,81 @@ openUploader({
       description="Drag-and-drop image upload with server-side Sharp processing. One file in, every configured size out. Ships with six presets covering podcasts, OG images, avatars, logos, and favicons. The inline preview can open the uploaded variants in the shared image WindowPanel."
     >
       <div className="w-full max-w-2xl space-y-4">
+        <div className="rounded-lg border border-border bg-background/50 p-3 space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <ControlGroup label="Mode">
+              <SegmentedOption
+                active={mode === "asset"}
+                onClick={() => {
+                  setMode("asset");
+                  setPasteCaptureMode("asset");
+                  setUploadedIds([]);
+                }}
+              >
+                Asset
+              </SegmentedOption>
+              <SegmentedOption
+                active={mode === "cloud"}
+                onClick={() => {
+                  setMode("cloud");
+                  setPasteCaptureMode("cloud");
+                  setResult(null);
+                }}
+              >
+                Cloud
+              </SegmentedOption>
+            </ControlGroup>
+
+            <ControlGroup label="Paste">
+              {(["auto", "off", "asset", "cloud"] as const).map((value) => (
+                <SegmentedOption
+                  key={value}
+                  active={pasteCaptureMode === value}
+                  onClick={() => setPasteCaptureMode(value)}
+                >
+                  {value}
+                </SegmentedOption>
+              ))}
+            </ControlGroup>
+
+            <ControlGroup label="Visibility">
+              {(["public", "private"] as const).map((value) => (
+                <SegmentedOption
+                  key={value}
+                  active={visibility === value}
+                  onClick={() => setVisibility(value)}
+                >
+                  {value}
+                </SegmentedOption>
+              ))}
+            </ControlGroup>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            <ToggleRow
+              checked={allowUrlPaste}
+              label="URL paste"
+              onChange={setAllowUrlPaste}
+            />
+            <ToggleRow
+              checked={enableViewerAction}
+              label="Viewer action"
+              onChange={setEnableViewerAction}
+            />
+            <ToggleRow checked={compact} label="Compact" onChange={setCompact} />
+            <ToggleRow
+              checked={hideVariantBadges}
+              label="Hide variant badges"
+              onChange={setHideVariantBadges}
+            />
+            <ToggleRow
+              checked={multiple}
+              label="Multiple files"
+              onChange={setMultiple}
+            />
+          </div>
+        </div>
+
         <div className="flex flex-wrap gap-2">
           {PRESETS.map((p) => (
             <button
@@ -142,12 +235,19 @@ openUploader({
 
         <div className="border border-border rounded-xl p-4 bg-muted/10">
           <ImageAssetUploader
+            mode={mode}
             preset={preset}
             onComplete={setResult}
+            onUploaded={setUploadedIds}
             currentUrl={result?.primary_url ?? null}
             currentVariants={result}
-            pasteCaptureMode="asset"
-            enableViewerAction
+            pasteCaptureMode={pasteCaptureMode}
+            visibility={visibility}
+            allowUrlPaste={allowUrlPaste}
+            enableViewerAction={enableViewerAction}
+            compact={compact}
+            hideVariantBadges={hideVariantBadges}
+            multiple={multiple}
             label={`${preset.charAt(0).toUpperCase()}${preset.slice(1)} image`}
           />
         </div>
@@ -181,7 +281,77 @@ openUploader({
             </pre>
           </div>
         )}
+
+        {uploadedIds.length > 0 && (
+          <div className="rounded-lg border border-border bg-muted/20 p-3 space-y-1.5">
+            <p className="text-xs font-medium">Cloud upload file ids</p>
+            <pre className="text-[11px] font-mono text-muted-foreground whitespace-pre-wrap break-all">
+              {JSON.stringify(uploadedIds, null, 2)}
+            </pre>
+          </div>
+        )}
       </div>
     </ComponentDisplayWrapper>
+  );
+}
+
+function ControlGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[11px] font-medium text-muted-foreground">{label}</p>
+      <div className="flex flex-wrap gap-1">{children}</div>
+    </div>
+  );
+}
+
+function SegmentedOption({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-border bg-background text-muted-foreground hover:border-primary/50"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ToggleRow({
+  checked,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 rounded-md border border-border bg-background px-2.5 py-2 text-xs">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="h-3.5 w-3.5"
+      />
+      <span>{label}</span>
+    </label>
   );
 }

--- a/app/(authenticated)/(admin-auth)/administration/official-components/component-displays/image-asset-uploader.tsx
+++ b/app/(authenticated)/(admin-auth)/administration/official-components/component-displays/image-asset-uploader.tsx
@@ -68,6 +68,7 @@ import { useOpenImageUploaderWindow } from '@/features/window-panels/windows/ima
 <ImageAssetUploader
   preset="social"                    // "social" | "cover" | "avatar" | "logo" | "favicon" | "square"
   currentUrl={form.image_url}
+  pasteCaptureMode="asset"           // paste clipboard images into the Sharp variant pipeline
   enableViewerAction                 // preview opens the shared image window panel
   onComplete={(result) => {
     if (!result) return clear();
@@ -94,7 +95,7 @@ openUploader({
 // Features
 // - Server-side Sharp pipeline: all variants share one original, stay consistent
 // - 6 presets covering every common image shape (social, logo, favicon, …)
-// - Drag-drop, click, OR paste a public URL
+// - Drag-drop, click, clipboard paste, OR paste a public URL
 // - Cloud-files backed uploads with configurable visibility + folder
 // - Optional preview action opens uploaded variants in the shared image panel`;
 
@@ -145,6 +146,7 @@ openUploader({
             onComplete={setResult}
             currentUrl={result?.primary_url ?? null}
             currentVariants={result}
+            pasteCaptureMode="asset"
             enableViewerAction
             label={`${preset.charAt(0).toUpperCase()}${preset.slice(1)} image`}
           />

--- a/app/(authenticated)/(admin-auth)/administration/official-components/parts/component-list.tsx
+++ b/app/(authenticated)/(admin-auth)/administration/official-components/parts/component-list.tsx
@@ -532,7 +532,7 @@ export const componentList: ComponentEntry[] = [
     name: "Image Asset Uploader",
     path: "components/official/ImageAssetUploader.tsx",
     description:
-      "Drag-and-drop image upload with Sharp-processed variants (cover/OG/thumbnail/avatar/logo/favicon). Single pipeline for every place in the app that needs consistently-sized image URLs, with an optional preview action into the shared image WindowPanel.",
+      "Official image-first dropzone. Supports Sharp-processed asset variants (cover/OG/thumbnail/avatar/logo/favicon) and Cloud Files upload mode for plain image uploads, with optional preview action into the shared image WindowPanel.",
     categories: ["inputs", "media", "utilities"],
     tags: [
       "image",

--- a/app/(authenticated)/(admin-auth)/administration/official-components/parts/component-list.tsx
+++ b/app/(authenticated)/(admin-auth)/administration/official-components/parts/component-list.tsx
@@ -532,7 +532,7 @@ export const componentList: ComponentEntry[] = [
     name: "Image Asset Uploader",
     path: "components/official/ImageAssetUploader.tsx",
     description:
-      "Official image-first dropzone. Supports Sharp-processed asset variants (cover/OG/thumbnail/avatar/logo/favicon) and Cloud Files upload mode for plain image uploads, with optional preview action into the shared image WindowPanel.",
+      "Official image-first dropzone. Supports Sharp-processed asset variants (cover/OG/thumbnail/avatar/logo/favicon), Cloud Files upload mode for plain image uploads, optional clipboard paste capture, and optional preview action into the shared image WindowPanel.",
     categories: ["inputs", "media", "utilities"],
     tags: [
       "image",

--- a/components/image/cloud/CloudUploadTab.tsx
+++ b/components/image/cloud/CloudUploadTab.tsx
@@ -1,11 +1,11 @@
 /**
  * components/image/cloud/CloudUploadTab.tsx
  *
- * Single consolidated upload surface that replaces the legacy "Upload",
- * "Paste", and "Quick Upload" tabs. Wraps `<FileUploadDropzone>` from
- * the cloud-files feature so paste-from-clipboard, drag-and-drop, and
- * the OS file picker all flow through the same code path with live
- * progress and the duplicate-detection guard mounted globally.
+ * Single consolidated image upload surface that replaces the legacy
+ * "Upload", "Paste", and "Quick Upload" tabs. Wraps the official
+ * `<ImageAssetUploader mode="cloud">` so the Image Manager uses one
+ * consistent image-first dropzone while still flowing through the
+ * cloud-files upload pipeline.
  *
  * Files land in `defaultUploadFolderPath` (default "Images/Uploads") —
  * resolved once via `ensureFolderPath`. Users can override the
@@ -35,11 +35,10 @@ import {
   selectFileById,
 } from "@/features/files/redux/selectors";
 import { ensureFolderPath } from "@/features/files/redux/thunks";
-import { FileUploadDropzone } from "@/features/files/components/core/FileUploadDropzone/FileUploadDropzone";
 import { openFolderPicker } from "@/features/files/components/pickers/cloudFilesPickerOpeners";
+import { ImageAssetUploader } from "@/components/official/ImageAssetUploader";
 import {
   useSelectedImages,
-  type ImageSource,
 } from "@/components/image/context/SelectedImagesProvider";
 import {
   buildCloudImageSource,
@@ -201,14 +200,17 @@ export function CloudUploadTab({
   return (
     <div className="h-full flex flex-col">
       <div className="flex-1 overflow-auto p-4 space-y-4">
-        <FileUploadDropzone
+        <ImageAssetUploader
+          mode="cloud"
           parentFolderId={folderId}
           visibility={visibility}
           accept={accept}
-          mode="inline"
           enablePaste
+          multiple
           onUploaded={handleUploaded}
           onError={handleError}
+          label="Upload"
+          allowUrlPaste={false}
         />
 
         {!hideFolderControls ? (

--- a/components/official/ImageAssetUploader.tsx
+++ b/components/official/ImageAssetUploader.tsx
@@ -70,7 +70,13 @@ export interface ImageAssetUploaderProps {
     parentFolderId?: string | null;
     /** Max size per cloud-mode file in bytes (UI-only; server enforces its own cap). */
     maxSize?: number;
-    /** Enable paste from clipboard in cloud mode. Defaults true. */
+    /**
+     * Clipboard paste capture. Defaults to "auto": enabled for cloud mode,
+     * disabled for asset mode. Use "asset" to let a variant uploader process
+     * pasted clipboard images through `/api/images/upload`.
+     */
+    pasteCaptureMode?: 'auto' | 'off' | 'cloud' | 'asset';
+    /** Enable paste from clipboard in cloud mode. Defaults true. Prefer `pasteCaptureMode` for new code. */
     enablePaste?: boolean;
     /** Allow multiple files in cloud mode. Asset mode always uses the first file. */
     multiple?: boolean;
@@ -213,6 +219,12 @@ export function formatCloudUploadFailures(
     return failed.map((f) => `${f.name}: ${f.error}`).join('; ');
 }
 
+export function buildPastedImageFileName(mimeType: string, timestamp = Date.now()) {
+    const subtype = mimeType.split('/')[1]?.toLowerCase();
+    const ext = subtype === 'jpeg' ? 'jpg' : subtype || 'png';
+    return `pasted-${timestamp}.${ext}`;
+}
+
 export function ImageAssetUploader({
     mode = 'asset',
     onComplete,
@@ -220,6 +232,7 @@ export function ImageAssetUploader({
     onError,
     parentFolderId = null,
     maxSize,
+    pasteCaptureMode = 'auto',
     enablePaste = true,
     multiple = false,
     preset = 'social',
@@ -400,8 +413,12 @@ export function ImageAssetUploader({
         disabled,
     });
 
+    const resolvedPasteCaptureMode = pasteCaptureMode === 'auto'
+        ? mode === 'cloud' && enablePaste ? 'cloud' : 'off'
+        : pasteCaptureMode;
+
     useEffect(() => {
-        if (mode !== 'cloud' || !enablePaste || typeof window === 'undefined') return;
+        if (resolvedPasteCaptureMode === 'off' || typeof window === 'undefined') return;
         const handler = (event: ClipboardEvent) => {
             if (!event.clipboardData?.items) return;
             const images: File[] = [];
@@ -409,18 +426,21 @@ export function ImageAssetUploader({
                 if (!item.type.startsWith('image/')) continue;
                 const blob = item.getAsFile();
                 if (!blob) continue;
-                const ext = blob.type.split('/')[1] ?? 'png';
-                images.push(new File([blob], `pasted-${Date.now()}.${ext}`, { type: blob.type }));
+                images.push(new File([blob], buildPastedImageFileName(blob.type), { type: blob.type }));
             }
             if (!images.length) return;
             event.preventDefault();
             setPasteHighlight(true);
             setTimeout(() => setPasteHighlight(false), 400);
-            void uploadCloudFiles(images);
+            if (resolvedPasteCaptureMode === 'cloud') {
+                void uploadCloudFiles(images);
+                return;
+            }
+            void uploadFile(images[0]);
         };
         window.addEventListener('paste', handler);
         return () => window.removeEventListener('paste', handler);
-    }, [mode, enablePaste, uploadCloudFiles]);
+    }, [resolvedPasteCaptureMode, uploadCloudFiles, uploadFile]);
 
     const presetLabels = PRESET_VARIANT_LABELS[preset];
     const blurb = PRESET_BLURB[preset];
@@ -590,8 +610,10 @@ export function ImageAssetUploader({
                             </p>
                             <p className="text-xs text-muted-foreground mt-0.5">
                                 {mode === 'cloud'
-                                    ? enablePaste ? 'JPG, PNG, WebP · Paste with Ctrl/⌘V' : 'JPG, PNG, WebP'
-                                    : `JPG, PNG, WebP · ${blurb}`}
+                                    ? resolvedPasteCaptureMode === 'cloud' ? 'JPG, PNG, WebP · Paste with Ctrl/⌘V' : 'JPG, PNG, WebP'
+                                    : resolvedPasteCaptureMode === 'asset'
+                                        ? `JPG, PNG, WebP · ${blurb} · Paste with Ctrl/⌘V`
+                                        : `JPG, PNG, WebP · ${blurb}`}
                             </p>
                         </div>
                     </div>

--- a/components/official/ImageAssetUploader.tsx
+++ b/components/official/ImageAssetUploader.tsx
@@ -24,13 +24,18 @@
  *   - "square"   1024²
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
 import { AlertCircle, CheckCircle2, Eye, ImageIcon, Link as LinkIcon, Loader2, Trash2, Upload, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { ImagePreset, ImageUploadResponse } from '@/app/api/images/upload/route';
 import type { Visibility } from '@/features/files/types';
-import { useAppDispatch } from '@/lib/redux/hooks';
+import { useAppDispatch, useAppSelector } from '@/lib/redux/hooks';
 import { openOverlay } from '@/lib/redux/slices/overlaySlice';
+import { selectActiveUploads } from '@/features/files/redux/selectors';
+import { useFileUpload } from '@/features/files/hooks/useFileUpload';
+import { UploadProgressList } from '@/features/files/components/core/FileUploadDropzone/UploadProgressList';
+import { extractErrorMessage } from '@/utils/errors';
 
 // ── Types exported for consumers ──────────────────────────────────────────
 
@@ -50,8 +55,25 @@ export interface ImageUploaderResult extends ImageUploaderVariants {
 }
 
 export interface ImageAssetUploaderProps {
+    /**
+     * Upload pipeline. "asset" preserves the Sharp variant flow. "cloud"
+     * uses the Cloud Files upload pipeline with this uploader's image-first UI.
+     */
+    mode?: 'asset' | 'cloud';
     /** Fires whenever URLs change (successful upload or removal). */
-    onComplete: (result: ImageUploaderResult | null) => void;
+    onComplete?: (result: ImageUploaderResult | null) => void;
+    /** Fires after cloud-mode uploads complete with new cloud file ids. */
+    onUploaded?: (fileIds: string[]) => void;
+    /** Fires when cloud-mode upload fails or an asset-mode upload errors. */
+    onError?: (message: string) => void;
+    /** Parent folder for cloud-mode uploads. null = root. */
+    parentFolderId?: string | null;
+    /** Max size per cloud-mode file in bytes (UI-only; server enforces its own cap). */
+    maxSize?: number;
+    /** Enable paste from clipboard in cloud mode. Defaults true. */
+    enablePaste?: boolean;
+    /** Allow multiple files in cloud mode. Asset mode always uses the first file. */
+    multiple?: boolean;
     /** Preset dictating the variant dimensions. Default: "social". */
     preset?: ImagePreset;
     /** Primary image URL already set (shows as existing preview). */
@@ -83,8 +105,8 @@ export interface ImageAssetUploaderProps {
     label?: string;
     /** Hide the variant chips row even when URLs exist. */
     hideVariantBadges?: boolean;
-    /** Accept attribute for the file input. */
-    accept?: string;
+    /** Accept attribute / dropzone patterns for the file input. */
+    accept?: string | string[];
     /** Disable the whole uploader. */
     disabled?: boolean;
     /** Extra classes on the outer wrapper. */
@@ -185,8 +207,21 @@ function StatusIcon({ state }: { state: UploadState }) {
     return null;
 }
 
+export function formatCloudUploadFailures(
+    failed: Array<{ name: string; error: string }>,
+) {
+    return failed.map((f) => `${f.name}: ${f.error}`).join('; ');
+}
+
 export function ImageAssetUploader({
+    mode = 'asset',
     onComplete,
+    onUploaded,
+    onError,
+    parentFolderId = null,
+    maxSize,
+    enablePaste = true,
+    multiple = false,
     preset = 'social',
     currentUrl,
     currentVariants,
@@ -203,8 +238,10 @@ export function ImageAssetUploader({
     className,
 }: ImageAssetUploaderProps) {
     const dispatch = useAppDispatch();
-    const inputRef = useRef<HTMLInputElement>(null);
+    const activeUploads = useAppSelector(selectActiveUploads);
+    const { upload } = useFileUpload({ parentFolderId, visibility });
     const [section, setSection] = useState<SectionState>({ state: 'idle', error: null, fileName: null });
+    const [pasteHighlight, setPasteHighlight] = useState(false);
     const [variants, setVariants] = useState<ImageUploaderVariants>({
         image_url: currentUrl ?? currentVariants?.image_url ?? null,
         og_image_url: currentVariants?.og_image_url ?? null,
@@ -249,21 +286,64 @@ export function ImageAssetUploader({
                 tiny_url: data.tiny_url,
             };
             setVariants(next);
-            onComplete({ ...next, primary_url: data.primary_url, preset: data.preset });
+            onComplete?.({ ...next, primary_url: data.primary_url, preset: data.preset });
             setSection({ state: 'success', error: null, fileName: file.name });
         } catch (err) {
             const message = err instanceof Error ? err.message : 'Upload failed';
             setSection({ state: 'error', error: message, fileName: file.name });
+            onError?.(message);
         }
     }, [disabled, preset, bucket, folder, visibility, onComplete]);
+
+    const uploadCloudFiles = useCallback(async (files: File[]) => {
+        if (disabled || !files.length) return;
+        const uploadFiles = multiple ? files : files.slice(0, 1);
+        setSection({
+            state: 'uploading',
+            error: null,
+            fileName: uploadFiles.length === 1 ? uploadFiles[0].name : `${uploadFiles.length} files`,
+        });
+        try {
+            const { uploaded, failed, cancelled } = await upload(uploadFiles, {
+                parentFolderId,
+                visibility,
+            });
+            if (uploaded.length) {
+                onUploaded?.(uploaded);
+                setSection({
+                    state: 'success',
+                    error: null,
+                    fileName: uploadFiles.length === 1 ? uploadFiles[0].name : `${uploaded.length} files`,
+                });
+            } else if (cancelled) {
+                setSection({ state: 'idle', error: null, fileName: null });
+            }
+            if (failed.length) {
+                const message = formatCloudUploadFailures(failed);
+                setSection({
+                    state: 'error',
+                    error: message,
+                    fileName: uploadFiles.length === 1 ? uploadFiles[0].name : `${failed.length} failed`,
+                });
+                onError?.(message);
+            }
+        } catch (err) {
+            const message = extractErrorMessage(err);
+            setSection({
+                state: 'error',
+                error: message,
+                fileName: uploadFiles.length === 1 ? uploadFiles[0].name : `${uploadFiles.length} files`,
+            });
+            onError?.(message);
+        }
+    }, [disabled, multiple, upload, parentFolderId, visibility, onUploaded, onError]);
 
     const remove = useCallback((e?: React.MouseEvent) => {
         e?.stopPropagation();
         const cleared: ImageUploaderVariants = { image_url: null, og_image_url: null, thumbnail_url: null, tiny_url: null };
         setVariants(cleared);
-        onComplete(null);
+        onComplete?.(null);
         setSection({ state: 'idle', error: null, fileName: null });
-        if (inputRef.current) inputRef.current.value = '';
     }, [onComplete]);
 
     const applyPastedUrl = useCallback(() => {
@@ -276,21 +356,75 @@ export function ImageAssetUploader({
             tiny_url: null,
         };
         setVariants(next);
-        onComplete({ ...next, primary_url: trimmed, preset });
+        onComplete?.({ ...next, primary_url: trimmed, preset });
         setSection({ state: 'idle', error: null, fileName: null });
         setShowUrlInput(false);
         setUrlDraft('');
     }, [urlDraft, onComplete, preset]);
 
-    const onDrop = useCallback((e: React.DragEvent) => {
-        e.preventDefault();
-        if (disabled) return;
-        const file = e.dataTransfer.files[0];
-        if (file?.type.startsWith('image/')) uploadFile(file);
-    }, [disabled, uploadFile]);
+    const handleFiles = useCallback((files: File[]) => {
+        if (mode === 'cloud') {
+            void uploadCloudFiles(files);
+            return;
+        }
+        const file = files[0];
+        if (file?.type.startsWith('image/')) void uploadFile(file);
+    }, [mode, uploadCloudFiles, uploadFile]);
+
+    const acceptValues = useMemo(
+        () => Array.isArray(accept) ? accept : accept.split(',').map((value) => value.trim()).filter(Boolean),
+        [accept],
+    );
+
+    const acceptMap = useMemo<Record<string, string[]> | undefined>(() => {
+        const mimePatterns = acceptValues.filter((pattern) => pattern.includes('/'));
+        if (!mimePatterns.length) return undefined;
+        return mimePatterns.reduce<Record<string, string[]>>((map, pattern) => {
+            map[pattern] = [];
+            return map;
+        }, {});
+    }, [acceptValues]);
+
+    const {
+        getRootProps,
+        getInputProps,
+        isDragActive,
+        open: openPicker,
+    } = useDropzone({
+        onDrop: (acceptedFiles) => handleFiles(acceptedFiles),
+        noClick: true,
+        noKeyboard: true,
+        accept: acceptMap,
+        maxSize,
+        multiple: mode === 'cloud' ? multiple : false,
+        disabled,
+    });
+
+    useEffect(() => {
+        if (mode !== 'cloud' || !enablePaste || typeof window === 'undefined') return;
+        const handler = (event: ClipboardEvent) => {
+            if (!event.clipboardData?.items) return;
+            const images: File[] = [];
+            for (const item of Array.from(event.clipboardData.items)) {
+                if (!item.type.startsWith('image/')) continue;
+                const blob = item.getAsFile();
+                if (!blob) continue;
+                const ext = blob.type.split('/')[1] ?? 'png';
+                images.push(new File([blob], `pasted-${Date.now()}.${ext}`, { type: blob.type }));
+            }
+            if (!images.length) return;
+            event.preventDefault();
+            setPasteHighlight(true);
+            setTimeout(() => setPasteHighlight(false), 400);
+            void uploadCloudFiles(images);
+        };
+        window.addEventListener('paste', handler);
+        return () => window.removeEventListener('paste', handler);
+    }, [mode, enablePaste, uploadCloudFiles]);
 
     const presetLabels = PRESET_VARIANT_LABELS[preset];
     const blurb = PRESET_BLURB[preset];
+    const highlighted = isDragActive || pasteHighlight;
     const dropZoneHeight = compact ? 'py-4' : 'py-6';
     const iconSize = compact ? 'h-6 w-6' : 'h-8 w-8';
     const viewerPayload = buildImageAssetViewerPayload({ variants, label, preset });
@@ -366,28 +500,26 @@ export function ImageAssetUploader({
 
             {/* Drop zone */}
             <div
-                onDrop={onDrop}
-                onDragOver={(e) => e.preventDefault()}
+                {...getRootProps()}
                 onClick={() => {
                     if (disabled || section.state === 'uploading') return;
-                    inputRef.current?.click();
+                    openPicker();
                 }}
                 className={cn(
                     'relative border-2 border-dashed rounded-xl transition-colors',
                     disabled
                         ? 'border-border bg-muted/30 cursor-not-allowed opacity-60'
-                        : section.state === 'uploading'
-                            ? 'border-primary/40 bg-primary/5 cursor-not-allowed'
-                            : 'border-border hover:border-primary/50 hover:bg-muted/30 cursor-pointer',
+                    : section.state === 'uploading'
+                        ? 'border-primary/40 bg-primary/5 cursor-not-allowed'
+                    : highlighted
+                        ? 'border-primary bg-primary/5 cursor-pointer'
+                        : 'border-border hover:border-primary/50 hover:bg-muted/30 cursor-pointer',
                 )}
             >
                 <input
-                    ref={inputRef}
-                    type="file"
-                    accept={accept}
-                    className="hidden"
-                    disabled={disabled}
-                    onChange={(e) => { const f = e.target.files?.[0]; if (f) uploadFile(f); }}
+                    {...getInputProps({
+                        accept: Array.isArray(accept) ? accept.join(',') : accept,
+                    })}
                 />
 
                 {variants.image_url ? (
@@ -452,15 +584,23 @@ export function ImageAssetUploader({
                         )}
                         <div className="text-center px-3">
                             <p className="text-sm font-medium text-foreground">
-                                {section.state === 'uploading' ? 'Processing…' : 'Drop image or click to upload'}
+                                {section.state === 'uploading'
+                                    ? mode === 'cloud' ? 'Uploading…' : 'Processing…'
+                                    : highlighted ? 'Drop to upload' : 'Drop image or click to upload'}
                             </p>
                             <p className="text-xs text-muted-foreground mt-0.5">
-                                JPG, PNG, WebP · {blurb}
+                                {mode === 'cloud'
+                                    ? enablePaste ? 'JPG, PNG, WebP · Paste with Ctrl/⌘V' : 'JPG, PNG, WebP'
+                                    : `JPG, PNG, WebP · ${blurb}`}
                             </p>
                         </div>
                     </div>
                 )}
             </div>
+
+            {mode === 'cloud' && activeUploads.length > 0 ? (
+                <UploadProgressList uploads={activeUploads} />
+            ) : null}
 
             {section.error && (
                 <p className="text-xs text-destructive flex items-center gap-1">

--- a/components/official/ImageAssetUploader.tsx
+++ b/components/official/ImageAssetUploader.tsx
@@ -561,16 +561,6 @@ export function ImageAssetUploader({
                             <p className="text-muted-foreground text-xs truncate">{section.fileName ?? 'Previously uploaded'}</p>
                             {!disabled && <p className="text-xs text-muted-foreground mt-0.5">Click to replace</p>}
                         </div>
-                        {variants.og_image_url && preset === 'social' && (
-                            /* eslint-disable-next-line @next/next/no-img-element */
-                            <img
-                                src={variants.og_image_url}
-                                alt="OG preview"
-                                className="w-20 h-11 rounded object-cover border shrink-0"
-                                title="1200×630 OG image"
-                                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                            />
-                        )}
                         {!disabled && (
                             <div className="shrink-0 flex items-center gap-1">
                                 {enableViewerAction && viewerPayload ? (

--- a/components/official/__tests__/ImageAssetUploader.test.ts
+++ b/components/official/__tests__/ImageAssetUploader.test.ts
@@ -1,4 +1,7 @@
-import { buildImageAssetViewerPayload } from "@/components/official/ImageAssetUploader";
+import {
+  buildImageAssetViewerPayload,
+  formatCloudUploadFailures,
+} from "@/components/official/ImageAssetUploader";
 
 describe("ImageAssetUploader", () => {
   it("builds a viewer payload from populated variants only", () => {
@@ -26,5 +29,16 @@ describe("ImageAssetUploader", () => {
       ],
       title: "Organization logo",
     });
+  });
+
+  it("formats cloud upload failures with filename and backend reason", () => {
+    expect(
+      formatCloudUploadFailures([
+        { name: "hero.png", error: "File is too large" },
+        { name: "logo.webp", error: "Unsupported content type" },
+      ]),
+    ).toBe(
+      "hero.png: File is too large; logo.webp: Unsupported content type",
+    );
   });
 });

--- a/components/official/__tests__/ImageAssetUploader.test.ts
+++ b/components/official/__tests__/ImageAssetUploader.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildPastedImageFileName,
   buildImageAssetViewerPayload,
   formatCloudUploadFailures,
 } from "@/components/official/ImageAssetUploader";
@@ -39,6 +40,18 @@ describe("ImageAssetUploader", () => {
       ]),
     ).toBe(
       "hero.png: File is too large; logo.webp: Unsupported content type",
+    );
+  });
+
+  it("builds stable pasted image filenames from mime types", () => {
+    expect(buildPastedImageFileName("image/png", 1710000000000)).toBe(
+      "pasted-1710000000000.png",
+    );
+    expect(buildPastedImageFileName("image/jpeg", 1710000000000)).toBe(
+      "pasted-1710000000000.jpg",
+    );
+    expect(buildPastedImageFileName("", 1710000000000)).toBe(
+      "pasted-1710000000000.png",
     );
   });
 });

--- a/features/files/FEATURE.md
+++ b/features/files/FEATURE.md
@@ -168,7 +168,7 @@ components/
 │   ├── FileIcon/         # icon + color by extension/mime
 │   ├── FileMeta/         # size, date, owner, permission chips
 │   ├── FilePreview/      # registry + type-specific previewers (Code/Image/Audio/Video/PDF/Text/Data/Generic)
-│   ├── FileUploadDropzone/
+│   ├── FileUploadDropzone/ # generic file-manager dropzone + overlay surfaces
 │   ├── FileBreadcrumbs/
 │   ├── FileActions/      # headless actions: rename, move, delete, download, share, copyLink, restoreVersion
 │   ├── FileContextMenu/
@@ -314,6 +314,7 @@ See [migration/MASTER-PLAN.md](migration/MASTER-PLAN.md) for the phase-ordered p
 
 ## Change log
 
+- **2026-05-07** — Image Manager upload boundary clarified. `/images/upload` now uses `components/official/ImageAssetUploader` in `mode="cloud"` for the image-first dropzone while still calling the Cloud Files `useFileUpload` pipeline. `FileUploadDropzone` remains the generic file-manager uploader for `/files`, embedded files surfaces, mobile stack, and overlay upload flows.
 - **2026-05-06** — RAG consolidation. Extracted every RAG-shaped surface from `features/files/` into the new top-level `features/rag/` feature. Moved out of this directory: `api/rag-ingest.ts` → `features/rag/api/ingest.ts`, `api/rag-search.ts` → `features/rag/api/search.ts`, `hooks/useFileIngest.ts` → `features/rag/hooks/useFileIngest.ts`, `hooks/useRagSearch.ts` → `features/rag/hooks/useRagSearch.ts`, `components/core/RagActions/ProcessForRagButton.tsx` → `features/rag/components/ProcessForRagButton.tsx`, `components/core/RagSearch/RagSearchHits.tsx` → `features/rag/components/search/RagSearchHits.tsx`. **Stayed in `features/files/`:** `redux/rag-thunks.ts`, `components/surfaces/desktop/RagStatusCell.tsx`, `components/surfaces/desktop/RagFilterPicker.tsx` — these are file-table chrome that read `cloudFiles.ragStatus` from this slice; moving them would split the slice across features. Also relocated the sister features `features/library/` → `features/rag/components/library/` (+ hooks/api/types extracted to `features/rag/{hooks,api,types}/`), `features/data-stores/` → `features/rag/components/data-stores/`, `features/documents/` → `features/rag/components/documents/`, and `features/rag-search-ui/` → `features/rag/components/search/`. All `DocumentTab.tsx` and `BulkActionsBar.tsx` imports updated; behaviour unchanged.
 - **2026-05-05** — Image Manager Hub absorbed `<ImageAssetUploader>` (Sharp variant pipeline) as a Branded Upload tab and embedded `CloudFilesTab` into a Studio Library tab. Cloud-files data is now consumed by both `<ImageManager>` (modal) and the new `/image-manager` route via `features/image-manager/registry/sections.ts`. No data-model changes — only consumers added. See [`features/image-manager/FEATURE.md`](../image-manager/FEATURE.md).
 - **2026-04-23** — Phase 0 kickoff. Created FEATURE.md, SKILL.md, PYTHON_TEAM_COMMS.md, migration/ scaffold. No runtime code yet.

--- a/features/image-manager/FEATURE.md
+++ b/features/image-manager/FEATURE.md
@@ -117,7 +117,7 @@ Primary group:
 1. **Public Images** (`PublicImagesSection`) — Curated Covers chip + Unsplash search. Curated covers come from `features/canvas/social/preset-covers.ts`.
 2. **Your Cloud** (`CloudImagesTab`) — image-filtered view of `cloud_files`. Includes a per-tile `Info` button that opens the `CloudFileMetadataSheet` side drawer.
 3. **All Files** (`CloudFilesTab`) — full cloud-files browser. Includes a "Photos" link to `/files/photos` for the deeper file-management view.
-4. **Upload** (`CloudUploadTab`) — drag/drop/paste/picker. Includes a collapsible "Paste base64 instead" sub-tool (`Base64DecoderShell`).
+4. **Upload** (`CloudUploadTab`) — image-first drag/drop/paste/picker powered by `<ImageAssetUploader mode="cloud">`, while preserving the Cloud Files upload pipeline. Includes a collapsible "Paste base64 instead" sub-tool (`Base64DecoderShell`).
 5. **Branded Upload** (`BrandedUploadTab`) — wraps `<ImageAssetUploader>`. Presets: `social | cover | avatar | logo | favicon | square`. Generated variants are auto-pushed to `SelectedImagesProvider`.
 6. **Image Studio** (`FullImageStudioTab`, id `studio-full`) — embeds the full three-column `<ImageStudioShell>` (the same component that powers `/image-studio/convert`). Lazy-loaded with `dynamic(... ssr: false)`. Users get the complete preset-catalog → file-card grid → export-panel pipeline without leaving the hub.
 7. **Studio Light** (`ImageStudioTab`, id `image-studio`) — embeds the picker-tuned `<EmbeddedImageStudio hideTitle>`. Returns variant URLs straight to `SelectedImagesProvider`, which the full shell does not — picker callers still want this.
@@ -145,8 +145,8 @@ Adding a new tile is a `ToolDescriptor` append — see `ToolsTab.tsx`.
 
 ### Cloud upload flow
 
-1. User picks/drops a file in `CloudUploadTab` (or pastes base64 into the sub-tool).
-2. `useFileUpload` writes to `cloud_files` via the upload pipeline in `features/files/`.
+1. User picks/drops a file in `CloudUploadTab` (or pastes an image into the page; base64 stays in the sub-tool).
+2. `<ImageAssetUploader mode="cloud">` renders the shared official image dropzone and calls `useFileUpload`, so bytes still write to `cloud_files` via the upload pipeline in `features/files/`.
 3. New `CloudFileRecord` is added to the cloud-files Redux slice, which ripples into Your Cloud / All Files automatically (no refetch needed).
 4. `CloudUploadTab` calls `addImage()` with the resolved URL so the upload becomes selectable in the footer preview row.
 
@@ -171,6 +171,7 @@ Adding a new tile is a `ToolDescriptor` append — see `ToolsTab.tsx`.
 - **`group: "tools"` is route-only.** The modal calls `buildImageManagerSections({ variant: "modal", showTools: false })`. Don't put primary functionality under `tools`.
 - **`SelectedImagesProvider.selectionMode === "none"` is "Browse".** Don't add a 4th mode — the contract is enumerated and consumed in two surfaces. Reuse `none`.
 - **`Base64DecoderShell` lives in `features/image-studio`** — Image Manager imports it. If Image Studio moves, update the import in `CloudUploadTab.tsx`.
+- **`/images/upload` uses `ImageAssetUploader` in cloud mode, not `FileUploadDropzone`.** Keep `FileUploadDropzone` in `features/files` for generic files and overlay upload surfaces; Image Manager uses the official image-first uploader for visual consistency.
 - **Server-only Unsplash key.** `NEXT_PUBLIC_UNSPLASH_ACCESS_KEY` was removed. Every Unsplash call goes through `/api/unsplash` via `hooks/images/unsplashClient.ts` (or the GET form for `PublicImageSearch`). Don't reintroduce a `NEXT_PUBLIC_*` Unsplash key.
 - **`ImageManagerContent` is a deprecated alias** of `<ImageManager>` — kept for legacy callers. New code imports `ImageManager` directly.
 
@@ -197,6 +198,7 @@ The Image Manager Hub plan landed across Phases 1–7 (May 2026). Pending owner-
 
 ## Change log
 
+- `2026-05-07` — `/images/upload` now renders `<ImageAssetUploader mode="cloud">` for the main image dropzone, preserving the existing Cloud Files upload pipeline, folder picker, paste support, selection integration, and base64 sub-tool while aligning the Upload and Branded Upload visual affordances.
 - `2026-05-07` — My Cloud image bulk selection: extracted image grid/list renderers, added per-image bulk checkboxes, wired a shared floating selection toolbar for download/move/visibility/delete/cancel, and reused the official empty-state card for empty results.
 - `2026-05-07` — Browse-mode image preview gained icon-only rotate-left, rotate-right, flip-horizontal, and flip-vertical controls in the shared Image Viewer window.
 - `2026-05-07` — My Cloud search now uses the official `SearchInput`, matching Public Search while preserving the existing filename filter behavior.

--- a/features/image-manager/FEATURE.md
+++ b/features/image-manager/FEATURE.md
@@ -118,7 +118,7 @@ Primary group:
 2. **Your Cloud** (`CloudImagesTab`) — image-filtered view of `cloud_files`. Includes a per-tile `Info` button that opens the `CloudFileMetadataSheet` side drawer.
 3. **All Files** (`CloudFilesTab`) — full cloud-files browser. Includes a "Photos" link to `/files/photos` for the deeper file-management view.
 4. **Upload** (`CloudUploadTab`) — image-first drag/drop/paste/picker powered by `<ImageAssetUploader mode="cloud">`, while preserving the Cloud Files upload pipeline. Includes a collapsible "Paste base64 instead" sub-tool (`Base64DecoderShell`).
-5. **Branded Upload** (`BrandedUploadTab`) — wraps `<ImageAssetUploader>`. Presets: `social | cover | avatar | logo | favicon | square`. Generated variants are auto-pushed to `SelectedImagesProvider`.
+5. **Branded Upload** (`BrandedUploadTab`) — wraps `<ImageAssetUploader pasteCaptureMode="asset">`. Presets: `social | cover | avatar | logo | favicon | square`. Dragged, picked, or pasted images run through the Sharp variant pipeline and generated variants are auto-pushed to `SelectedImagesProvider`.
 6. **Image Studio** (`FullImageStudioTab`, id `studio-full`) — embeds the full three-column `<ImageStudioShell>` (the same component that powers `/image-studio/convert`). Lazy-loaded with `dynamic(... ssr: false)`. Users get the complete preset-catalog → file-card grid → export-panel pipeline without leaving the hub.
 7. **Studio Light** (`ImageStudioTab`, id `image-studio`) — embeds the picker-tuned `<EmbeddedImageStudio hideTitle>`. Returns variant URLs straight to `SelectedImagesProvider`, which the full shell does not — picker callers still want this.
 8. **Studio Library** (`StudioLibraryTab`) — read-only embed of the `Images/Generated/...` cloud folder. Resolves the folder ID via `ensureFolderPath`, then keys a `<CloudFilesTab>` to it.
@@ -159,8 +159,8 @@ Adding a new tile is a `ToolDescriptor` append — see `ToolsTab.tsx`.
 
 ### Branded upload flow (Sharp variants)
 
-1. User picks a preset chip and uploads.
-2. `<ImageAssetUploader>` POSTs to `/api/images/upload` with the preset key.
+1. User picks a preset chip and uploads by drop, picker, or clipboard paste.
+2. `<ImageAssetUploader pasteCaptureMode="asset">` POSTs to `/api/images/upload` with the preset key.
 3. Server returns `{ image_url, primary_url, social_url, ... }` — every populated URL is auto-added to `SelectedImagesProvider` so the user can drag the variant into a form afterwards.
 
 ---
@@ -199,6 +199,7 @@ The Image Manager Hub plan landed across Phases 1–7 (May 2026). Pending owner-
 ## Change log
 
 - `2026-05-07` — `/images/upload` now renders `<ImageAssetUploader mode="cloud">` for the main image dropzone, preserving the existing Cloud Files upload pipeline, folder picker, paste support, selection integration, and base64 sub-tool while aligning the Upload and Branded Upload visual affordances.
+- `2026-05-07` — Branded Upload now opts into `ImageAssetUploader pasteCaptureMode="asset"`, so clipboard images can be pasted directly into the Sharp variant pipeline.
 - `2026-05-07` — My Cloud image bulk selection: extracted image grid/list renderers, added per-image bulk checkboxes, wired a shared floating selection toolbar for download/move/visibility/delete/cancel, and reused the official empty-state card for empty results.
 - `2026-05-07` — Browse-mode image preview gained icon-only rotate-left, rotate-right, flip-horizontal, and flip-vertical controls in the shared Image Viewer window.
 - `2026-05-07` — My Cloud search now uses the official `SearchInput`, matching Public Search while preserving the existing filename filter behavior.

--- a/features/image-manager/components/BrandedUploadTab.tsx
+++ b/features/image-manager/components/BrandedUploadTab.tsx
@@ -166,6 +166,7 @@ export function BrandedUploadTab() {
         onComplete={handleComplete}
         label={`${preset.label} upload`}
         visibility="public"
+        pasteCaptureMode="asset"
       />
 
       {lastResult ? (


### PR DESCRIPTION
## Summary
- Adds a cloud upload mode to `ImageAssetUploader` so Image Manager can use one official image-first dropzone.
- Switches `/images/upload` from `FileUploadDropzone` to `ImageAssetUploader mode="cloud"` while preserving the Cloud Files upload pipeline, paste support, folder destination, progress, and selection integration.
- Adds explicit clipboard paste capture for asset-mode uploads and exposes a live prop playground on the official component page.
- Clarifies the upload boundary in Image Manager / Files docs: `FileUploadDropzone` remains the generic file-manager uploader.

## Commit story

### `62959f103 feat: consolidate image upload dropzone`
**What changed:** Added `mode="cloud"` to `ImageAssetUploader`, switched `/images/upload` to use it, and updated the feature docs/official registry.

**Why we did it:** The Upload and Branded Upload surfaces had different dropzone implementations. This gives Image Manager one official image-first upload UI while keeping the existing Cloud Files upload pipeline and leaving the generic `/files` uploader untouched.

### `a2bbb9e61 feat: add image uploader paste capture`
**What changed:** Added `pasteCaptureMode` and pasted-image filename handling, then opted Branded Upload into `pasteCaptureMode="asset"`.

**Why we did it:** Clipboard paste should be a first-class image upload path, not only drag/drop or file picker. The prop keeps the behavior explicit so asset uploads can process pasted images through Sharp while cloud uploads can continue using Cloud Files.

### `6d364a827 fix: enable paste capture in image uploader demo`
**What changed:** Updated the official component demo to pass `pasteCaptureMode="asset"` and documented that in the snippet.

**Why we did it:** The component supported paste capture, but the demo page did not opt in, so pasting on the page appeared broken. This makes the demo match the intended behavior.

### `aac7a3f83 feat: add image uploader prop playground`
**What changed:** Added live controls on the official component page for mode, paste capture, visibility, URL paste, viewer action, compact layout, variant badges, and multiple uploads.

**Why we did it:** Reviewers need to test the component’s prop surface without editing code. The page now acts as a small playground for validating behavior combinations.

### `32d9a91ec fix: remove duplicate social preview thumbnail`
**What changed:** Removed the inline OG/social thumbnail shown only for the social preset.

**Why we did it:** The eye icon already opens the generated variant preview, and variant badges already show which sizes exist. Removing the extra thumbnail reduces clutter and keeps all presets visually consistent.

## Validation
- `pnpm jest components/official/__tests__/ImageAssetUploader.test.ts --no-coverage` passes.
- `git diff --check` passes for touched files.
- `pnpm type-check` needs `NODE_OPTIONS=--max-old-space-size=8192` to complete in this repo; with that, it reports existing unrelated errors outside this change.
- Targeted ESLint could not start locally because `eslint-plugin-no-barrel-files` is missing from the installed dependencies.

## Notes for reviewers
- Test the prop playground at `/administration/official-components/image-asset-uploader`.
- Test `/images/upload` for Cloud Files upload behavior.
- Test `/images/branded` for Sharp variant uploads and clipboard paste capture.
