### PR TITLE
fix: Cache cloud image preview URLs

### DIFF
--- a/components/image/cloud/CloudFilesTab.tsx
+++ b/components/image/cloud/CloudFilesTab.tsx
@@ -57,6 +57,7 @@ import {
   buildCloudImageSource,
   resolveCloudFileUrl,
 } from "@/components/image/cloud/resolveCloudFileUrl";
+import { buildCloudFilesBrowsePayload } from "@/components/image/cloud/cloudFilesBrowsePayload";
 import { useBrowseAction } from "@/features/image-manager/browse/BrowseImageProvider";
 import { toast } from "sonner";
 import { CloudFilesBrowserTable } from "./CloudFilesBrowserTable";
@@ -157,26 +158,16 @@ export function CloudFilesTab({
         const imageRows = fileRows.filter((f) =>
           isImageMime(resolveMime(f.mimeType, f.fileName)),
         );
-        const resolved = await Promise.all(
-          imageRows.map((f) =>
-            resolveCloudFileUrl(store, f.id).catch(() => null),
-          ),
-        );
-        const urls: string[] = [];
-        const alts: string[] = [];
-        let initialIndex = 0;
-        for (let i = 0; i < imageRows.length; i += 1) {
-          const url = resolved[i];
-          if (!url) continue;
-          if (imageRows[i].id === file.id) initialIndex = urls.length;
-          urls.push(url);
-          alts.push(imageRows[i].fileName);
-        }
-        if (urls.length === 0) {
+        const payload = await buildCloudFilesBrowsePayload({
+          imageRows,
+          activeFileId: file.id,
+          resolveUrl: (fileId) => resolveCloudFileUrl(store, fileId),
+        });
+        if (payload.images.length === 0) {
           toast.error("Couldn't load that image");
           return;
         }
-        browse({ images: urls, alts, initialIndex, title: file.fileName });
+        browse({ ...payload, title: file.fileName });
       } finally {
         setResolvingId(null);
       }

--- a/components/image/cloud/cloudFilesBrowsePayload.test.ts
+++ b/components/image/cloud/cloudFilesBrowsePayload.test.ts
@@ -1,0 +1,26 @@
+import { buildCloudFilesBrowsePayload } from "@/components/image/cloud/cloudFilesBrowsePayload";
+
+describe("buildCloudFilesBrowsePayload", () => {
+  it("passes plain URL strings to the image viewer payload", async () => {
+    const payload = await buildCloudFilesBrowsePayload({
+      imageRows: [
+        { id: "cover", fileName: "cover.jpg" },
+        { id: "thumb", fileName: "thumb.jpg" },
+      ],
+      activeFileId: "thumb",
+      resolveUrl: async (fileId) => ({
+        url: `https://cdn.example.com/${fileId}.jpg`,
+        expiresAt: null,
+      }),
+    });
+
+    expect(payload).toEqual({
+      images: [
+        "https://cdn.example.com/cover.jpg",
+        "https://cdn.example.com/thumb.jpg",
+      ],
+      alts: ["cover.jpg", "thumb.jpg"],
+      initialIndex: 1,
+    });
+  });
+});

--- a/components/image/cloud/cloudFilesBrowsePayload.test.ts
+++ b/components/image/cloud/cloudFilesBrowsePayload.test.ts
@@ -23,4 +23,29 @@ describe("buildCloudFilesBrowsePayload", () => {
       initialIndex: 1,
     });
   });
+
+  it("returns an empty payload when the active image fails to resolve", async () => {
+    const payload = await buildCloudFilesBrowsePayload({
+      imageRows: [
+        { id: "cover", fileName: "cover.jpg" },
+        { id: "thumb", fileName: "thumb.jpg" },
+      ],
+      activeFileId: "thumb",
+      resolveUrl: async (fileId) => {
+        if (fileId === "thumb") {
+          throw new Error("signed URL failed");
+        }
+        return {
+          url: `https://cdn.example.com/${fileId}.jpg`,
+          expiresAt: null,
+        };
+      },
+    });
+
+    expect(payload).toEqual({
+      images: [],
+      alts: [],
+      initialIndex: 0,
+    });
+  });
 });

--- a/components/image/cloud/cloudFilesBrowsePayload.ts
+++ b/components/image/cloud/cloudFilesBrowsePayload.ts
@@ -1,0 +1,39 @@
+import type { ResolvedCloudUrl } from "@/components/image/cloud/resolveCloudFileUrl";
+
+interface BrowsePayloadFile {
+  id: string;
+  fileName: string;
+}
+
+export interface CloudFilesBrowsePayload {
+  images: string[];
+  alts: string[];
+  initialIndex: number;
+}
+
+export async function buildCloudFilesBrowsePayload({
+  imageRows,
+  activeFileId,
+  resolveUrl,
+}: {
+  imageRows: BrowsePayloadFile[];
+  activeFileId: string;
+  resolveUrl: (fileId: string) => Promise<ResolvedCloudUrl>;
+}): Promise<CloudFilesBrowsePayload> {
+  const resolved = await Promise.all(
+    imageRows.map((file) => resolveUrl(file.id).catch(() => null)),
+  );
+  const images: string[] = [];
+  const alts: string[] = [];
+  let initialIndex = 0;
+
+  for (let i = 0; i < imageRows.length; i += 1) {
+    const resolvedUrl = resolved[i];
+    if (!resolvedUrl) continue;
+    if (imageRows[i].id === activeFileId) initialIndex = images.length;
+    images.push(resolvedUrl.url);
+    alts.push(imageRows[i].fileName);
+  }
+
+  return { images, alts, initialIndex };
+}

--- a/components/image/cloud/cloudFilesBrowsePayload.ts
+++ b/components/image/cloud/cloudFilesBrowsePayload.ts
@@ -26,13 +26,21 @@ export async function buildCloudFilesBrowsePayload({
   const images: string[] = [];
   const alts: string[] = [];
   let initialIndex = 0;
+  let activeResolved = false;
 
   for (let i = 0; i < imageRows.length; i += 1) {
     const resolvedUrl = resolved[i];
     if (!resolvedUrl) continue;
-    if (imageRows[i].id === activeFileId) initialIndex = images.length;
+    if (imageRows[i].id === activeFileId) {
+      initialIndex = images.length;
+      activeResolved = true;
+    }
     images.push(resolvedUrl.url);
     alts.push(imageRows[i].fileName);
+  }
+
+  if (!activeResolved) {
+    return { images: [], alts: [], initialIndex: 0 };
   }
 
   return { images, alts, initialIndex };

--- a/components/image/cloud/resolveCloudFileUrl.ts
+++ b/components/image/cloud/resolveCloudFileUrl.ts
@@ -20,6 +20,7 @@ import { selectFileById } from "@/features/files/redux/selectors";
 import type { CloudFileRecord } from "@/features/files/types";
 import type { AppStore } from "@/lib/redux/store";
 import type { ImageSource } from "@/components/image/context/SelectedImagesProvider";
+import { resolveRenderableImageUrl } from "@/features/files/utils/resolveRenderableImageUrl";
 
 export interface ResolvedCloudUrl {
   url: string;
@@ -39,15 +40,15 @@ export async function resolveCloudFileUrl(
     throw new Error(`Cloud file not found in store: ${fileId}`);
   }
   if (file.publicUrl) {
-    return { url: file.publicUrl, expiresAt: null };
+    return resolveRenderableImageUrl(file);
   }
-  const { data } = await Files.getSignedUrl(fileId, {
+  return resolveRenderableImageUrl(file, {
     expiresIn: options.expiresIn ?? DEFAULT_EXPIRES_IN_SECONDS,
+    getSignedUrl: async (id, params) => {
+      const { data } = await Files.getSignedUrl(id, params);
+      return data;
+    },
   });
-  return {
-    url: data.url,
-    expiresAt: Date.now() + data.expires_in * 1000,
-  };
 }
 
 /**

--- a/features/files/FEATURE.md
+++ b/features/files/FEATURE.md
@@ -2,7 +2,7 @@
 
 **Status:** ✅ Phase 11 complete. Legacy system deleted, cloud-files is the only file system in the app.
 **Owner:** Files migration team.
-**Last updated:** 2026-05-06.
+**Last updated:** 2026-05-08.
 
 This is the live architecture doc for the new file management system under `features/files/`. It supersedes the legacy Supabase-Storage-based system progressively over 12 phases ([migration/MASTER-PLAN.md](migration/MASTER-PLAN.md)).
 
@@ -288,7 +288,8 @@ Do not violate. If you're tempted, update this doc first with the reasoning.
 7. **Realtime dedup via request ledger** — every REST write ships a `requestId`.
 8. **Dialog on desktop, Drawer on mobile** — enforced by surface branching.
 9. **`dvh` not `vh`** under `app/(a)/files/`.
-10. **Docs updated in the same change as code.**
+10. **Renderable image/file URLs are centrally cached** — use [utils/resolveRenderableImageUrl.ts](utils/resolveRenderableImageUrl.ts) or hooks/helpers that delegate to it. Do not call `/files/{id}/url` directly from image or thumbnail UI; signed URLs must be reused while valid and refreshed when expired.
+11. **Docs updated in the same change as code.**
 
 ---
 
@@ -314,6 +315,7 @@ See [migration/MASTER-PLAN.md](migration/MASTER-PLAN.md) for the phase-ordered p
 
 ## Change log
 
+- **2026-05-08** — Central renderable image URL resolver added at [utils/resolveRenderableImageUrl.ts](utils/resolveRenderableImageUrl.ts). It accepts public URLs, cloud file records, file ids, and image-source metadata; caches signed URL results by cloud file id; reuses valid signed URLs; and refreshes expired known cloud-file URLs. `useSignedUrl()` and Image Manager cloud-file resolution now delegate through this path.
 - **2026-05-07** — Image Manager upload boundary clarified. `/images/upload` now uses `components/official/ImageAssetUploader` in `mode="cloud"` for the image-first dropzone while still calling the Cloud Files `useFileUpload` pipeline. `FileUploadDropzone` remains the generic file-manager uploader for `/files`, embedded files surfaces, mobile stack, and overlay upload flows.
 - **2026-05-06** — RAG consolidation. Extracted every RAG-shaped surface from `features/files/` into the new top-level `features/rag/` feature. Moved out of this directory: `api/rag-ingest.ts` → `features/rag/api/ingest.ts`, `api/rag-search.ts` → `features/rag/api/search.ts`, `hooks/useFileIngest.ts` → `features/rag/hooks/useFileIngest.ts`, `hooks/useRagSearch.ts` → `features/rag/hooks/useRagSearch.ts`, `components/core/RagActions/ProcessForRagButton.tsx` → `features/rag/components/ProcessForRagButton.tsx`, `components/core/RagSearch/RagSearchHits.tsx` → `features/rag/components/search/RagSearchHits.tsx`. **Stayed in `features/files/`:** `redux/rag-thunks.ts`, `components/surfaces/desktop/RagStatusCell.tsx`, `components/surfaces/desktop/RagFilterPicker.tsx` — these are file-table chrome that read `cloudFiles.ragStatus` from this slice; moving them would split the slice across features. Also relocated the sister features `features/library/` → `features/rag/components/library/` (+ hooks/api/types extracted to `features/rag/{hooks,api,types}/`), `features/data-stores/` → `features/rag/components/data-stores/`, `features/documents/` → `features/rag/components/documents/`, and `features/rag-search-ui/` → `features/rag/components/search/`. All `DocumentTab.tsx` and `BulkActionsBar.tsx` imports updated; behaviour unchanged.
 - **2026-05-05** — Image Manager Hub absorbed `<ImageAssetUploader>` (Sharp variant pipeline) as a Branded Upload tab and embedded `CloudFilesTab` into a Studio Library tab. Cloud-files data is now consumed by both `<ImageManager>` (modal) and the new `/image-manager` route via `features/image-manager/registry/sections.ts`. No data-model changes — only consumers added. See [`features/image-manager/FEATURE.md`](../image-manager/FEATURE.md).

--- a/features/files/hooks/useSignedUrl.ts
+++ b/features/files/hooks/useSignedUrl.ts
@@ -12,6 +12,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as Files from "@/features/files/api/files";
+import { resolveRenderableImageUrl } from "@/features/files/utils/resolveRenderableImageUrl";
 import { extractErrorMessage } from "@/utils/errors";
 
 const SAFETY_MARGIN_MS = 30 * 1000; // refresh 30s before expiry
@@ -52,9 +53,18 @@ export function useSignedUrl(
     setLoading(true);
     setError(null);
     try {
-      const { data } = await Files.getSignedUrl(fileId, { expiresIn });
-      setUrl(data.url);
-      expiresAtRef.current = Date.now() + data.expires_in * 1000;
+      const result = await resolveRenderableImageUrl(
+        { fileId },
+        {
+          expiresIn,
+          getSignedUrl: async (id, params) => {
+            const { data } = await Files.getSignedUrl(id, params);
+            return data;
+          },
+        },
+      );
+      setUrl(result.url);
+      expiresAtRef.current = result.expiresAt ?? Number.POSITIVE_INFINITY;
     } catch (err) {
       const msg = extractErrorMessage(err);
       setError(msg);
@@ -75,6 +85,7 @@ export function useSignedUrl(
   // Auto-refresh before expiry.
   useEffect(() => {
     if (!url) return;
+    if (!Number.isFinite(expiresAtRef.current)) return;
     const msUntilExpiry = expiresAtRef.current - Date.now() - SAFETY_MARGIN_MS;
     if (msUntilExpiry <= 0) {
       void fetchUrl();

--- a/features/files/utils/resolveRenderableImageUrl.test.ts
+++ b/features/files/utils/resolveRenderableImageUrl.test.ts
@@ -1,0 +1,89 @@
+import {
+  __clearRenderableImageUrlCacheForTests,
+  resolveRenderableImageUrl,
+} from "@/features/files/utils/resolveRenderableImageUrl";
+
+describe("resolveRenderableImageUrl", () => {
+  beforeEach(() => {
+    __clearRenderableImageUrlCacheForTests();
+    jest.useRealTimers();
+  });
+
+  it("reuses a cached signed URL until it is close to expiry", async () => {
+    const getSignedUrl = jest
+      .fn()
+      .mockResolvedValueOnce({ url: "https://signed.example.com/one", expires_in: 3600 });
+
+    const first = await resolveRenderableImageUrl(
+      { fileId: "file-1" },
+      { getSignedUrl, now: () => 1_000 },
+    );
+    const second = await resolveRenderableImageUrl(
+      { fileId: "file-1" },
+      { getSignedUrl, now: () => 2_000 },
+    );
+
+    expect(first.url).toBe("https://signed.example.com/one");
+    expect(second.url).toBe("https://signed.example.com/one");
+    expect(getSignedUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes concurrent signed URL requests for the same file", async () => {
+    let resolveRequest:
+      | ((value: { url: string; expires_in: number }) => void)
+      | null = null;
+    const getSignedUrl = jest.fn(
+      () =>
+        new Promise<{ url: string; expires_in: number }>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+
+    const first = resolveRenderableImageUrl({ fileId: "file-1" }, { getSignedUrl });
+    const second = resolveRenderableImageUrl({ fileId: "file-1" }, { getSignedUrl });
+    resolveRequest?.({ url: "https://signed.example.com/shared", expires_in: 3600 });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ url: "https://signed.example.com/shared" }),
+      expect.objectContaining({ url: "https://signed.example.com/shared" }),
+    ]);
+    expect(getSignedUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes a known cloud file URL after expiry", async () => {
+    const getSignedUrl = jest
+      .fn()
+      .mockResolvedValueOnce({ url: "https://signed.example.com/fresh", expires_in: 3600 });
+
+    const result = await resolveRenderableImageUrl(
+      {
+        url: "https://signed.example.com/expired",
+        metadata: {
+          fileId: "file-1",
+          urlExpiresAt: 1_000,
+        },
+      },
+      { getSignedUrl, now: () => 2_000 },
+    );
+
+    expect(result.url).toBe("https://signed.example.com/fresh");
+    expect(getSignedUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves an id-only cloud file record through the signed URL cache", async () => {
+    const getSignedUrl = jest
+      .fn()
+      .mockResolvedValueOnce({ url: "https://signed.example.com/from-record", expires_in: 3600 });
+
+    const result = await resolveRenderableImageUrl(
+      {
+        id: "file-1",
+        publicUrl: null,
+      },
+      { getSignedUrl, now: () => 1_000 },
+    );
+
+    expect(result.url).toBe("https://signed.example.com/from-record");
+    expect(getSignedUrl).toHaveBeenCalledWith("file-1", { expiresIn: 3600 });
+  });
+});

--- a/features/files/utils/resolveRenderableImageUrl.test.ts
+++ b/features/files/utils/resolveRenderableImageUrl.test.ts
@@ -86,4 +86,30 @@ describe("resolveRenderableImageUrl", () => {
     expect(result.url).toBe("https://signed.example.com/from-record");
     expect(getSignedUrl).toHaveBeenCalledWith("file-1", { expiresIn: 3600 });
   });
+
+  it("does not reuse a public cloud file URL after the record no longer has publicUrl", async () => {
+    const getSignedUrl = jest
+      .fn()
+      .mockResolvedValueOnce({ url: "https://signed.example.com/private", expires_in: 3600 });
+
+    const publicResult = await resolveRenderableImageUrl(
+      {
+        id: "cloud:file-1",
+        publicUrl: "https://cdn.example.com/public-cover.jpg",
+      },
+      { getSignedUrl, now: () => 1_000 },
+    );
+    const privateResult = await resolveRenderableImageUrl(
+      {
+        id: "file-1",
+        fileName: "cover.jpg",
+        publicUrl: null,
+      },
+      { getSignedUrl, now: () => 2_000 },
+    );
+
+    expect(publicResult.url).toBe("https://cdn.example.com/public-cover.jpg");
+    expect(privateResult.url).toBe("https://signed.example.com/private");
+    expect(getSignedUrl).toHaveBeenCalledTimes(1);
+  });
 });

--- a/features/files/utils/resolveRenderableImageUrl.ts
+++ b/features/files/utils/resolveRenderableImageUrl.ts
@@ -1,0 +1,214 @@
+import type { ImageSource } from "@/components/image/context/SelectedImagesProvider";
+import type { SignedUrlResponse } from "@/features/files/types";
+
+const DEFAULT_EXPIRES_IN_SECONDS = 3600;
+const EXPIRY_SAFETY_MARGIN_MS = 30 * 1000;
+
+interface CachedUrl {
+  url: string;
+  expiresAt: number | null;
+}
+
+const urlCache = new Map<string, CachedUrl>();
+const inFlight = new Map<string, Promise<CachedUrl>>();
+
+export interface RenderableImageUrlResult {
+  url: string;
+  expiresAt: number | null;
+}
+
+export interface RenderableImageUrlOptions {
+  expiresIn?: number;
+  getSignedUrl?: (
+    fileId: string,
+    params: { expiresIn?: number },
+  ) => Promise<Pick<SignedUrlResponse, "url" | "expires_in">>;
+  now?: () => number;
+}
+
+export type RenderableImageRef =
+  | string
+  | ImageSource
+  | {
+      id?: string;
+      fileId?: string | null;
+      url?: string | null;
+      publicUrl?: string | null;
+      metadata?: Record<string, unknown> | null;
+    };
+
+export async function resolveRenderableImageUrl(
+  ref: RenderableImageRef,
+  options: RenderableImageUrlOptions = {},
+): Promise<RenderableImageUrlResult> {
+  const normalized = normalizeImageRef(ref);
+  const now = options.now ?? Date.now;
+
+  if (normalized.publicUrl) {
+    return remember(normalized.cacheKey ?? normalized.publicUrl, {
+      url: normalized.publicUrl,
+      expiresAt: null,
+    });
+  }
+
+  if (normalized.fileId) {
+    const cached = urlCache.get(cacheKeyForFile(normalized.fileId));
+    if (cached && isUsable(cached, now())) return cached;
+  }
+
+  const currentUrl = normalized.url;
+  const currentExpiresAt =
+    normalized.expiresAt ?? (currentUrl ? getAwsSignedUrlExpiry(currentUrl) : null);
+  if (currentUrl && isUsable({ url: currentUrl, expiresAt: currentExpiresAt }, now())) {
+    if (normalized.fileId) {
+      return remember(cacheKeyForFile(normalized.fileId), {
+        url: currentUrl,
+        expiresAt: currentExpiresAt,
+      });
+    }
+    return { url: currentUrl, expiresAt: currentExpiresAt };
+  }
+
+  if (!normalized.fileId) {
+    if (currentUrl) return { url: currentUrl, expiresAt: currentExpiresAt };
+    throw new Error("Image reference does not include a renderable URL or file id");
+  }
+
+  if (!options.getSignedUrl) {
+    throw new Error("Resolving a private cloud file requires getSignedUrl");
+  }
+
+  return fetchAndCacheSignedUrl(normalized.fileId, options);
+}
+
+export function __clearRenderableImageUrlCacheForTests() {
+  urlCache.clear();
+  inFlight.clear();
+}
+
+function fetchAndCacheSignedUrl(
+  fileId: string,
+  options: RenderableImageUrlOptions,
+): Promise<CachedUrl> {
+  const key = cacheKeyForFile(fileId);
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  const promise = options
+    .getSignedUrl!(fileId, {
+      expiresIn: options.expiresIn ?? DEFAULT_EXPIRES_IN_SECONDS,
+    })
+    .then((data) =>
+      remember(key, {
+        url: data.url,
+        expiresAt: (options.now ?? Date.now)() + data.expires_in * 1000,
+      }),
+    )
+    .finally(() => {
+      inFlight.delete(key);
+    });
+
+  inFlight.set(key, promise);
+  return promise;
+}
+
+function remember(key: string, value: CachedUrl): CachedUrl {
+  urlCache.set(key, value);
+  return value;
+}
+
+function isUsable(value: CachedUrl, now: number) {
+  return value.expiresAt === null || value.expiresAt - EXPIRY_SAFETY_MARGIN_MS > now;
+}
+
+function cacheKeyForFile(fileId: string) {
+  return `cloud-file:${fileId}`;
+}
+
+function normalizeImageRef(ref: RenderableImageRef): {
+  fileId: string | null;
+  url: string | null;
+  publicUrl: string | null;
+  expiresAt: number | null;
+  cacheKey: string | null;
+} {
+  if (typeof ref === "string") {
+    return {
+      fileId: null,
+      url: ref,
+      publicUrl: null,
+      expiresAt: getAwsSignedUrlExpiry(ref),
+      cacheKey: ref,
+    };
+  }
+
+  const metadata = isRecord(ref.metadata) ? ref.metadata : null;
+  const metadataFileId = readString(metadata, "fileId");
+  const metadataExpiresAt = readNumber(metadata, "urlExpiresAt");
+  const directFileId = readString(ref, "fileId");
+  const cloudId =
+    typeof ref.id === "string" && ref.id.startsWith("cloud:")
+      ? ref.id.slice("cloud:".length)
+      : null;
+  const url = typeof ref.url === "string" && ref.url.length > 0 ? ref.url : null;
+  const publicUrl =
+    typeof ref.publicUrl === "string" && ref.publicUrl.length > 0
+      ? ref.publicUrl
+      : null;
+  const idOnlyCloudFile =
+    !url &&
+    !publicUrl &&
+    typeof ref.id === "string" &&
+    ("publicUrl" in ref || "fileName" in ref);
+  const fileId =
+    directFileId ?? metadataFileId ?? cloudId ?? (idOnlyCloudFile ? ref.id! : null);
+
+  return {
+    fileId,
+    url,
+    publicUrl,
+    expiresAt: metadataExpiresAt ?? (url ? getAwsSignedUrlExpiry(url) : null),
+    cacheKey: fileId ? cacheKeyForFile(fileId) : url,
+  };
+}
+
+function getAwsSignedUrlExpiry(url: string): number | null {
+  try {
+    const parsed = new URL(url);
+    const date = parsed.searchParams.get("X-Amz-Date");
+    const expires = parsed.searchParams.get("X-Amz-Expires");
+    if (!date || !expires) return null;
+    const seconds = Number(expires);
+    if (!Number.isFinite(seconds)) return null;
+    const match = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/.exec(date);
+    if (!match) return null;
+    const [, year, month, day, hour, minute, second] = match;
+    const issuedAt = Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+      Number(second),
+    );
+    return issuedAt + seconds * 1000;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object");
+}
+
+function readString(value: Record<string, unknown> | null, key: string): string | null {
+  if (!value) return null;
+  const item = value[key];
+  return typeof item === "string" && item.length > 0 ? item : null;
+}
+
+function readNumber(value: Record<string, unknown> | null, key: string): number | null {
+  if (!value) return null;
+  const item = value[key];
+  return typeof item === "number" && Number.isFinite(item) ? item : null;
+}

--- a/features/files/utils/resolveRenderableImageUrl.ts
+++ b/features/files/utils/resolveRenderableImageUrl.ts
@@ -45,7 +45,7 @@ export async function resolveRenderableImageUrl(
   const now = options.now ?? Date.now;
 
   if (normalized.publicUrl) {
-    return remember(normalized.cacheKey ?? normalized.publicUrl, {
+    return remember(normalized.publicUrl, {
       url: normalized.publicUrl,
       expiresAt: null,
     });

--- a/features/image-manager/FEATURE.md
+++ b/features/image-manager/FEATURE.md
@@ -2,7 +2,7 @@
 
 **Status:** `active`
 **Tier:** `2`
-**Last updated:** `2026-05-07`
+**Last updated:** `2026-05-08`
 
 ---
 
@@ -153,7 +153,7 @@ Adding a new tile is a `ToolDescriptor` append — see `ToolsTab.tsx`.
 ### Browse-mode click
 
 1. Tab calls `useBrowseAction()` and gets a `browse(payload)` function.
-2. On click, the tab resolves the visible images to URLs and dispatches `browse({ images, alts, initialIndex, title })`.
+2. On click, the tab resolves cloud-file references through the shared cached renderer path (`features/files/utils/resolveRenderableImageUrl.ts` via `resolveCloudFileUrl`) and dispatches `browse({ images, alts, initialIndex, title })`.
 3. `<BrowseImageProvider>` invokes `openImageViewer(dispatch, payload)` from `ImageViewerWindow.tsx`, which dispatches `openOverlay({ overlayId: "imageViewer", instanceId: "default", data })`.
 4. `OverlayController` mounts `ImageViewerWindow` with the payload spread as props.
 
@@ -174,6 +174,7 @@ Adding a new tile is a `ToolDescriptor` append — see `ToolsTab.tsx`.
 - **`/images/upload` uses `ImageAssetUploader` in cloud mode, not `FileUploadDropzone`.** Keep `FileUploadDropzone` in `features/files` for generic files and overlay upload surfaces; Image Manager uses the official image-first uploader for visual consistency.
 - **Server-only Unsplash key.** `NEXT_PUBLIC_UNSPLASH_ACCESS_KEY` was removed. Every Unsplash call goes through `/api/unsplash` via `hooks/images/unsplashClient.ts` (or the GET form for `PublicImageSearch`). Don't reintroduce a `NEXT_PUBLIC_*` Unsplash key.
 - **`ImageManagerContent` is a deprecated alias** of `<ImageManager>` — kept for legacy callers. New code imports `ImageManager` directly.
+- **Cloud-file image URLs must resolve through the central cached resolver.** Use `resolveCloudFileUrl()` / `resolveRenderableImageUrl()` instead of calling `/files/{id}/url` directly from image-manager UI. Viewer payloads must pass plain URL strings, never resolver objects.
 
 ---
 
@@ -198,6 +199,7 @@ The Image Manager Hub plan landed across Phases 1–7 (May 2026). Pending owner-
 
 ## Change log
 
+- `2026-05-08` — All Files Browse-mode preview now converts cloud-file resolver results to plain image URL strings before opening `ImageViewerWindow`, fixing broken previews like `<img src="[object Object]">`. Cloud-file preview resolution now shares the cache-aware `resolveRenderableImageUrl` path so signed URLs are reused while valid and refreshed when expired.
 - `2026-05-07` — `/images/upload` now renders `<ImageAssetUploader mode="cloud">` for the main image dropzone, preserving the existing Cloud Files upload pipeline, folder picker, paste support, selection integration, and base64 sub-tool while aligning the Upload and Branded Upload visual affordances.
 - `2026-05-07` — Branded Upload now opts into `ImageAssetUploader pasteCaptureMode="asset"`, so clipboard images can be pasted directly into the Sharp variant pipeline.
 - `2026-05-07` — My Cloud image bulk selection: extracted image grid/list renderers, added per-image bulk checkboxes, wired a shared floating selection toolbar for download/move/visibility/delete/cancel, and reused the official empty-state card for empty results.


### PR DESCRIPTION
## Summary

Fixes the broken All Files image preview path and centralizes cloud-file image URL resolution so image surfaces reuse cached signed URLs instead of fetching fresh URLs repeatedly.

## Root cause

The All Files Browse-mode path resolved cloud-file images into `ResolvedCloudUrl` objects, then passed those objects directly to `ImageViewerWindow`, whose contract is `images: string[]`. That produced broken image renders like `<img src="[object Object]">`. The same area also used one-off signed URL fetches, so thumbnails and previews could repeatedly request URLs for the same file instead of sharing a cache.

## Commits

- `fix: cache cloud image preview urls` — adds `resolveRenderableImageUrl`, routes `useSignedUrl()` and `resolveCloudFileUrl()` through the shared cache, fixes the All Files browse payload to pass plain URL strings, and adds regression tests for cache reuse, concurrent request dedupe, expired URL refresh, id-only cloud records, and viewer payload shape.

## Validation

- `pnpm test:unit features/files/utils/resolveRenderableImageUrl.test.ts components/image/cloud/cloudFilesBrowsePayload.test.ts components/image/cloud/CloudImagesTab.test.tsx components/image/cloud/CloudImageGrid.test.tsx` passed: 8 tests.
- `pnpm type-check` timed out twice, including with a 5-minute timeout.
- Focused ESLint could not run because the repo config cannot resolve `eslint-plugin-no-barrel-files`.

## Note

This replaces the closed PR #10 after renaming the branch from `codex/cache-cloud-image-preview-urls` to `fiix/cache-cloud-image-preview-urls`.