### PR TITLE
fix(files): migrate remaining Api.Files callers + clear onError-blocked img bypasses

### DIFF
--- a/components/mardown-display/blocks/images/ImageOutputBlock.tsx
+++ b/components/mardown-display/blocks/images/ImageOutputBlock.tsx
@@ -37,9 +37,8 @@ import {
   DrawerTitle,
 } from "@/components/ui/drawer";
 import { toast } from "sonner";
-import { useFileAs } from "@/features/files";
+import { useFileAs, useFileMutation } from "@/features/files";
 import type { FileSource } from "@/features/files";
-import * as Files from "@/features/files/api/files";
 import { useIsMobile } from "@/hooks/use-mobile";
 
 // Extract the cloud_files UUID from an S3 path: /{userId}/{folder}/{uuid}.{ext}
@@ -139,6 +138,7 @@ const ImageOutputBlock: React.FC<ImageOutputBlockProps> = ({
   const [isDownloading, setIsDownloading] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const isMobile = useIsMobile();
+  const fileMutation = useFileMutation();
 
   useEffect(() => {
     setImageLoaded(false);
@@ -180,17 +180,16 @@ const ImageOutputBlock: React.FC<ImageOutputBlockProps> = ({
   };
 
   const handleShare = async () => {
-    const fileId = extractCloudFileId(url);
     if (!fileId) {
       await handleCopyLink();
       return;
     }
     try {
-      await Files.patchFile(fileId, { visibility: "public" });
-      const { data } = await Files.getSignedUrl(fileId, {
+      await fileMutation.setVisibility(fileId, "public");
+      const { url: publicUrl } = await fileMutation.signedUrl(fileId, {
         expiresIn: 604_800,
       });
-      await navigator.clipboard.writeText(data.url);
+      await navigator.clipboard.writeText(publicUrl);
       toast.success("Public link copied");
     } catch {
       try {

--- a/components/official/ImageAssetUploader.tsx
+++ b/components/official/ImageAssetUploader.tsx
@@ -40,7 +40,7 @@ import { useDropzone } from 'react-dropzone';
 import { AlertCircle, CheckCircle2, Eye, ImageIcon, Link as LinkIcon, Loader2, Trash2, Upload, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Asset, AssetPreset, AssetVariant, Visibility } from '@/features/files';
-import { useFileUpload } from '@/features/files';
+import { useFileUpload, InlineMediaRef } from '@/features/files';
 import { useAppDispatch } from '@/lib/redux/hooks';
 import { openOverlay } from '@/lib/redux/slices/overlaySlice';
 import { extractErrorMessage } from '@/utils/errors';
@@ -617,12 +617,15 @@ export function ImageAssetUploader({
 
                 {variants.image_url ? (
                     <div className="flex items-center gap-3 p-3">
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
-                            src={variants.thumbnail_url ?? variants.tiny_url ?? variants.image_url}
+                        <InlineMediaRef
+                            ref={variants.thumbnail_url ?? variants.tiny_url ?? variants.image_url}
+                            size={{ width: 56, height: 56 }}
+                            fit="cover"
+                            rounded="lg"
+                            border="subtle"
                             alt={label}
-                            className="w-14 h-14 rounded-lg object-cover border shrink-0"
-                            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                            className="shrink-0"
+                            onError={(e) => { (e.currentTarget as HTMLElement).style.display = 'none'; }}
                         />
                         <div className="min-w-0 flex-1 text-sm">
                             {section.state === 'success' && (

--- a/features/agents/components/builder/message-builders/AddBlockButton.tsx
+++ b/features/agents/components/builder/message-builders/AddBlockButton.tsx
@@ -37,7 +37,7 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { Upload } from "lucide-react";
 import { useOpenImageUploaderWindow } from "@/features/window-panels/windows/image/useOpenImageUploaderWindow";
-import { CloudFolders } from "@/features/files";
+import { CloudFolders, InlineMediaRef } from "@/features/files";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -592,13 +592,15 @@ export function BlockRow({
 
       {showThumbnail && (
         <div className="pl-5 pt-1 pb-1.5">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={imgUrl}
+          <InlineMediaRef
+            ref={imgUrl}
+            size={{ width: 0, height: 0 }}
+            fit="cover"
+            rounded="none"
             alt="Attached image"
-            className="h-16 w-auto max-w-[150px] rounded border border-border object-cover"
+            className="h-16 w-auto max-w-[150px] rounded border border-border"
             onError={(e) => {
-              (e.target as HTMLImageElement).style.display = "none";
+              (e.currentTarget as HTMLElement).style.display = "none";
             }}
           />
         </div>

--- a/features/agents/components/inputs/input-components/MediaVariableInput.tsx
+++ b/features/agents/components/inputs/input-components/MediaVariableInput.tsx
@@ -33,8 +33,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { useFileUpload } from "@/features/files";
-import { useFileSrc } from "@/features/files";
+import { useFileUpload, useFileSrc, InlineMediaRef } from "@/features/files";
 import { cn } from "@/lib/utils";
 
 // 36-char canonical UUID — what cld_files file_ids look like.
@@ -210,13 +209,15 @@ export function MediaVariableInput({
       {stored && (
         <div className="flex items-stretch gap-2 px-2 py-1.5 rounded-md border border-border bg-muted/40">
           {hasThumbnail ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={previewSrc!}
+            <InlineMediaRef
+              ref={previewSrc}
+              size={{ width: 40, height: 40 }}
+              fit="cover"
+              rounded="none"
               alt={variableName}
-              className="h-10 w-10 object-cover rounded border border-border shrink-0"
+              className="rounded border border-border shrink-0"
               onError={(e) => {
-                (e.currentTarget as HTMLImageElement).style.visibility = "hidden";
+                (e.currentTarget as HTMLElement).style.visibility = "hidden";
               }}
             />
           ) : (

--- a/features/audio/services/audioFallbackUpload.ts
+++ b/features/audio/services/audioFallbackUpload.ts
@@ -18,7 +18,6 @@
 
 "use client";
 
-import * as Api from "@/features/files/api";
 import { CloudFolders, fileHandler } from "@/features/files";
 import { extractErrorMessage } from "@/utils/errors";
 import { AUDIO_API_ROUTES, RETRY_CONFIG } from "../constants";
@@ -86,11 +85,11 @@ async function uploadWithRetry(
       const fileId = normalized.fileId;
 
       // Short-lived signed URL for the transcription service (10 min).
-      const { data: url } = await Api.Files.getSignedUrl(fileId, {
-        expiresIn: 600,
-      });
+      const signedUrl = await fileHandler
+        .use({ kind: "file_id", fileId })
+        .as({ kind: "html_src" });
 
-      return { fileId, signedUrl: url.url };
+      return { fileId, signedUrl };
     } catch (err) {
       lastError =
         err instanceof Error ? err : new Error(extractErrorMessage(err));
@@ -183,7 +182,7 @@ export async function uploadAndTranscribeFull(
         // service path and the slice's deleteFile thunk isn't part of
         // the public surface. The realtime channel will reconcile the
         // slice state asynchronously.
-        await Api.Files.deleteFile(handle.fileId, { hardDelete: true });
+        await fileHandler.remove(handle.fileId, { hard: true });
       } catch {
         // Non-critical cleanup — the file will be auto-pruned by the
         // backend's retention policy if the hard-delete fails.

--- a/features/files/handler/handler.ts
+++ b/features/files/handler/handler.ts
@@ -17,7 +17,10 @@ import { normalize } from "./input/normalize";
 import { resolve as resolveImpl } from "./resolver";
 import { toTarget } from "./output/target";
 import { getStoreSingleton } from "@/lib/redux/store-singleton";
-import { ensureFolderPath as ensureFolderPathThunk } from "@/features/files/redux/thunks";
+import {
+  deleteFile as deleteFileThunk,
+  ensureFolderPath as ensureFolderPathThunk,
+} from "@/features/files/redux/thunks";
 import type { EnsureFolderPathArg } from "@/features/files/types";
 import type { AppDispatch } from "@/lib/redux/store";
 import type {
@@ -105,6 +108,28 @@ export const fileHandler = {
    */
   async toContentPart(source: FileSource) {
     return this.use(source).as({ kind: "jsonb_content_part" });
+  },
+
+  /**
+   * Imperatively soft- or hard-delete a file. Routes through the
+   * `deleteFile` thunk against the store singleton so the slice and
+   * realtime channel stay in sync — identical to `useFileMutation().remove()`.
+   *
+   * For service-layer and non-React callers (e.g. cleanup after a failed
+   * upload). React components should prefer `useFileMutation` so they get
+   * hook-lifecycle guarantees.
+   */
+  async remove(fileId: string, options?: { hard?: boolean }): Promise<void> {
+    const store = getStoreSingleton();
+    if (!store) {
+      throw new Error(
+        "fileHandler.remove called before the Redux store was ready.",
+      );
+    }
+    const dispatch = store.dispatch as AppDispatch;
+    await dispatch(
+      deleteFileThunk({ fileId, hardDelete: options?.hard }),
+    ).unwrap();
   },
 
   /**

--- a/features/news/components/NewsFloatingWorkspace.tsx
+++ b/features/news/components/NewsFloatingWorkspace.tsx
@@ -6,6 +6,7 @@ import { fetchNews } from "@/actions/ai-actions/news-api";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import Image from "next/image";
+import { InlineMediaRef } from "@/features/files";
 
 const CATEGORIES = [
   "general",
@@ -175,11 +176,13 @@ function NewsItem({ article }: { article: Article }) {
         {/* Thumbnail */}
         <div className="w-20 h-20 shrink-0 bg-muted rounded border border-border/50 relative overflow-hidden flex items-center justify-center">
            {showImage ? (
-             // eslint-disable-next-line @next/next/no-img-element
-             <img
-               src={article.urlToImage}
+             <InlineMediaRef
+               ref={article.urlToImage}
+               size="fill"
+               fit="cover"
+               rounded="none"
                alt={article.title}
-               className="object-cover w-full h-full group-hover:scale-105 transition-transform duration-300"
+               className="group-hover:scale-105 transition-transform duration-300"
                onError={() => setImgError(true)}
              />
            ) : (

--- a/features/resource-manager/resource-picker/FilesResourcePicker.tsx
+++ b/features/resource-manager/resource-picker/FilesResourcePicker.tsx
@@ -33,8 +33,7 @@ import {
   type EnhancedFileDetails,
 } from "@/utils/file-operations/constants";
 import { useAppSelector } from "@/lib/redux/hooks";
-import * as Api from "@/features/files/api";
-import { useCloudTree } from "@/features/files";
+import { useCloudTree, useFileMutation } from "@/features/files";
 import {
   selectAllFilesMap,
   selectAllFoldersMap,
@@ -238,6 +237,7 @@ export function FilesResourcePicker({
   const foldersById = useAppSelector(selectAllFoldersMap);
   const rootFolderIds = useAppSelector(selectRootFolderIds);
 
+  const fileMutation = useFileMutation();
   const [searchQuery, setSearchQuery] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
 
@@ -264,10 +264,9 @@ export function FilesResourcePicker({
       // Fetch a short-lived signed URL. Unlike legacy storage, every
       // cloud-files URL is signed — we don't need the "public vs private"
       // dance the old picker did.
-      const { data } = await Api.Files.getSignedUrl(file.id, {
+      const { url: fileUrl } = await fileMutation.signedUrl(file.id, {
         expiresIn: 3600,
       });
-      const fileUrl = data.url;
 
       // Reuse the legacy EnhancedFileDetails shape so downstream callers
       // (resource registry, attachment pills, etc.) read the same fields.

--- a/features/tasks/services/taskService.ts
+++ b/features/tasks/services/taskService.ts
@@ -4,7 +4,6 @@ import { requireUserId } from "@/utils/auth/getUserId";
 import { getSharedWithMe } from "@/utils/permissions/service";
 import type { DbRpcRow } from "@/types/supabase-rpc";
 import type { DatabaseTask } from "../types";
-import * as FilesApi from "@/features/files/api";
 import { fileHandler, folderForTask } from "@/features/files";
 
 export interface CreateTaskInput {
@@ -248,7 +247,7 @@ export async function uploadTaskAttachment(
       // API (a thunk dispatch is overkill in this best-effort cleanup path;
       // realtime reconciles the slice asynchronously).
       try {
-        await FilesApi.Files.deleteFile(fileId, { hardDelete: false });
+        await fileHandler.remove(fileId, { hard: false });
       } catch {
         /* best effort */
       }
@@ -267,10 +266,9 @@ export async function uploadTaskAttachment(
  */
 export async function getAttachmentUrl(fileId: string): Promise<string> {
   try {
-    const { data } = await FilesApi.Files.getSignedUrl(fileId, {
-      expiresIn: 3600,
-    });
-    return data.url;
+    return await fileHandler
+      .use({ kind: "file_id", fileId })
+      .as({ kind: "html_src" });
   } catch (err) {
     console.error("Error resolving cloud-files signed URL:", err);
     return "";

--- a/features/workflows/results/registered-components/BraveSearchDisplay.tsx
+++ b/features/workflows/results/registered-components/BraveSearchDisplay.tsx
@@ -255,12 +255,15 @@ const BraveSearchDisplay: React.FC<BraveSearchDisplayProps> = ({ data }) => {
                                 <div className="flex items-start gap-2 p-3 pr-10">
                                     <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center mt-0.5">
                                         {result.profile?.img ? (
-                                            <img 
-                                                src={result.profile.img} 
-                                                alt="" 
+                                            <InlineMediaRef
+                                                ref={result.profile.img}
+                                                size={{ width: 16, height: 16 }}
+                                                fit="cover"
+                                                rounded="none"
+                                                alt=""
                                                 className="w-4 h-4 rounded"
                                                 onError={(e) => {
-                                                    e.currentTarget.style.display = "none";
+                                                    (e.currentTarget as HTMLElement).style.display = "none";
                                                 }}
                                             />
                                         ) : (
@@ -373,12 +376,15 @@ const BraveSearchDisplay: React.FC<BraveSearchDisplayProps> = ({ data }) => {
                                         >
                                             {video.thumbnail?.src && (
                                                 <div className="relative bg-gray-900 dark:bg-black">
-                                                    <img 
-                                                        src={video.thumbnail.src} 
-                                                        alt={video.title} 
-                                                        className="w-full aspect-video object-contain"
+                                                    <InlineMediaRef
+                                                        ref={video.thumbnail.src}
+                                                        size={{ width: 0, height: 0 }}
+                                                        fit="contain"
+                                                        rounded="none"
+                                                        alt={video.title}
+                                                        className="w-full aspect-video"
                                                         onError={(e) => {
-                                                            e.currentTarget.parentElement!.style.display = "none";
+                                                            (e.currentTarget as HTMLElement).parentElement!.style.display = "none";
                                                         }}
                                                     />
                                                     {video.video?.duration && (
@@ -465,12 +471,15 @@ const BraveSearchDisplay: React.FC<BraveSearchDisplayProps> = ({ data }) => {
                                     {/* Favicon */}
                                     <div className="flex-shrink-0 w-5 h-5 flex items-center justify-center">
                                         {result.profile?.img ? (
-                                            <img 
-                                                src={result.profile.img} 
-                                                alt="" 
+                                            <InlineMediaRef
+                                                ref={result.profile.img}
+                                                size={{ width: 20, height: 20 }}
+                                                fit="cover"
+                                                rounded="none"
+                                                alt=""
                                                 className="w-5 h-5 rounded"
                                                 onError={(e) => {
-                                                    e.currentTarget.style.display = "none";
+                                                    (e.currentTarget as HTMLElement).style.display = "none";
                                                 }}
                                             />
                                         ) : (


### PR DESCRIPTION
## Summary

Closes items 3 and 5 from `docs/FILE_HANDLING_GAP_ANALYSIS_2026-05-13.md`.

**Item 3 — remaining `Api.Files.getSignedUrl` namespace callers (4 files)**
- `audioFallbackUpload.ts` — removes banned `import * as Api from "@/features/files/api"`, replaces `getSignedUrl` with `fileHandler.use().as("html_src")`, `deleteFile` with `fileHandler.remove()`
- `taskService.ts` — same pattern, both callers migrated
- `FilesResourcePicker.tsx` — removes banned Api import, replaces with `useFileMutation().signedUrl()`
- `ImageOutputBlock.tsx` — removes `@/features/files/api/files` import, replaces `patchFile` + `getSignedUrl` with `useFileMutation().setVisibility()` + `signedUrl()`

**`fileHandler.remove()` added to `handler.ts`**
Service-layer code needed an imperative delete path. Routes through the `deleteFile` thunk via the store singleton — identical semantics to `useFileMutation().remove()`. Completes the handler's read/write/delete triad.

**Item 5 — `onError`-blocked `<img>` bypass sweep (6 files, 8 sites)**
Your recent `InlineMediaRef` update shipped `onError`/`onLoad`/`mediaElementRef`/`crossOrigin`. This sweep migrates every bypass that was waiting on that gap:
- `MediaVariableInput.tsx` — preview thumbnail hides on 404
- `AddBlockButton.tsx` — attached-image preview hides on 404
- `NewsFloatingWorkspace.tsx` — article thumbnail toggles `imgError` state on 404
- `BraveSearchDisplay.tsx` — profile icon ×2 and video thumbnail hide on 404
- `ImageAssetUploader.tsx` — processed-image preview hides on 404

## Test plan
- [ ] Upload an audio file in the WhatsApp clone — voice message sends (audioFallbackUpload path)
- [ ] Attach a file to a task — attachment URL resolves via `getAttachmentUrl`
- [ ] Open `FilesResourcePicker`, select a file — picker returns a URL and the resource attaches
- [ ] In a chat with an AI image, use Share → "Public link copied" fires; confirm visibility toggle
- [ ] Open `MediaVariableInput` with a media variable — thumbnail preview shows, broken URL hides the image
- [ ] Add an image block in AddBlockButton — preview renders, broken URL hides it
- [ ] News widget loads articles — thumbnails show; bad image URLs hide gracefully
- [ ] Brave search results show favicons and video thumbnails with graceful fallback on error
- [ ] ImageAssetUploader — processed image preview shows/hides on error