### PR TITLE
feat(notes): tab bar bug fixes and UI improvements

### DIFF
--- a/app/(a)/notes/notes.css
+++ b/app/(a)/notes/notes.css
@@ -411,10 +411,9 @@
   .notes-note-header { display: none !important; }
 }
 
-/* Tab close button — show on parent hover/active */
+/* Tab close button — show on parent hover/active, no transition for instant response */
 .notes-tab-close-btn {
   opacity: 0;
-  transition: opacity 150ms ease;
 }
 .group:hover .notes-tab-close-btn,
 .group[data-active="true"] .notes-tab-close-btn {

--- a/features/notes/components/NoteTabBar.tsx
+++ b/features/notes/components/NoteTabBar.tsx
@@ -231,7 +231,7 @@ export function NoteTabBar({ instanceId }: NoteTabBarProps) {
 
       <div
         ref={scrollRef}
-        className="flex items-stretch flex-1 min-w-0 overflow-x-auto h-full"
+        className="flex items-stretch flex-1 min-w-0 overflow-x-auto scrollbar-none h-full"
       >
         {openTabs.map((tabId) => (
           <div

--- a/features/notes/components/NoteTabBar.tsx
+++ b/features/notes/components/NoteTabBar.tsx
@@ -176,7 +176,10 @@ export function NoteTabBar({ instanceId }: NoteTabBarProps) {
     if (scrollBy !== 0) {
       container.scrollBy({ left: scrollBy, behavior: "smooth" });
     }
-  }, [activeTabId]);
+  // openTabs is included so the scroll also fires after moveActiveTabToFront —
+  // that action changes tab ORDER (not activeTabId), and without this the
+  // auto-moved tab would end up off-screen to the left.
+  }, [activeTabId, openTabs]);
 
   // ── Idle auto-move: active tab → position 0 ───────────────────────
   // Once the user has been quiet about tabs for `TAB_AUTO_MOVE_IDLE_MS`,
@@ -217,6 +220,15 @@ export function NoteTabBar({ instanceId }: NoteTabBarProps) {
       }}
       onDrop={handleDrop}
     >
+      {/* New note button — left of the scroll area, always visible */}
+      <button
+        className={cn(actionBtnClass, "shrink-0 self-center mx-1")}
+        onClick={handleNewTab}
+        title="New Note"
+      >
+        <Plus />
+      </button>
+
       <div
         ref={scrollRef}
         className="flex items-stretch flex-1 min-w-0 overflow-x-auto h-full"
@@ -245,15 +257,6 @@ export function NoteTabBar({ instanceId }: NoteTabBarProps) {
             <NoteTabItem noteId={tabId} instanceId={instanceId} />
           </div>
         ))}
-
-        {/* New note tab button */}
-        <button
-          className={cn(actionBtnClass, "shrink-0 self-center ml-1")}
-          onClick={handleNewTab}
-          title="New Note"
-        >
-          <Plus />
-        </button>
 
         {/* Split view button */}
         {activeTabId && !splitNoteId && (

--- a/features/notes/components/NoteTabItem.tsx
+++ b/features/notes/components/NoteTabItem.tsx
@@ -4,7 +4,7 @@
 // Matches ALL SSR workspace tab features:
 // - Editable title on active tab (debounced save)
 // - Dirty indicator (amber dot)
-// - Active tab action buttons: Save, Duplicate, Share, Folder, Delete, History, Voice
+// - Active tab: single ⋯ overflow menu (Save, Copy, Share, Folder, Context, Dictate, Delete)
 // - Close button on all tabs
 // - Right-click context menu
 // - DnD reordering
@@ -18,11 +18,11 @@ import {
   Share2,
   FolderInput,
   Trash2,
-  History,
   X,
   Download,
   Link2,
   Network,
+  MoreHorizontal,
 } from "lucide-react";
 import { MicrophoneIconButton } from "@/features/audio/components/MicrophoneIconButton";
 import { useAppDispatch, useAppSelector } from "@/lib/redux/hooks";
@@ -70,6 +70,9 @@ interface NoteTabItemProps {
 const actionBtnClass =
   "flex items-center justify-center w-6 h-6 rounded cursor-pointer transition-colors text-muted-foreground hover:bg-accent hover:text-foreground [&_svg]:w-3.5 [&_svg]:h-3.5";
 
+const menuItemClass =
+  "flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors cursor-pointer text-foreground hover:bg-accent";
+
 export function NoteTabItem({ noteId, instanceId }: NoteTabItemProps) {
   const dispatch = useAppDispatch();
 
@@ -91,12 +94,11 @@ export function NoteTabItem({ noteId, instanceId }: NoteTabItemProps) {
   const [localLabel, setLocalLabel] = useState(label);
   const [showFolderDrop, setShowFolderDrop] = useState(false);
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
+  const [overflowMenuPos, setOverflowMenuPos] = useState<{ right: number; top: number } | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
   const [contextOpen, setContextOpen] = useState(false);
   const [titleFocused, setTitleFocused] = useState(false);
   const labelTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const folderBtnRef = useRef<HTMLButtonElement>(null);
-  const contextBtnRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   // Sync Redux label → local
@@ -169,6 +171,7 @@ export function NoteTabItem({ noteId, instanceId }: NoteTabItemProps) {
   // touching anything else.
   const anyTabUiOpen =
     !!ctxMenu ||
+    !!overflowMenuPos ||
     showFolderDrop ||
     contextOpen ||
     shareOpen ||
@@ -235,7 +238,7 @@ export function NoteTabItem({ noteId, instanceId }: NoteTabItemProps) {
           "group flex items-center gap-0 px-[6px] text-[0.6875rem] font-medium whitespace-nowrap min-w-0 shrink-0 transition-colors",
           isActive
             ? "max-w-[340px] bg-accent/60 text-foreground"
-            : "max-w-[160px] bg-transparent text-muted-foreground hover:bg-accent/30 cursor-pointer",
+            : "max-w-[160px] bg-transparent text-muted-foreground/70 hover:text-muted-foreground hover:bg-accent/30 cursor-pointer",
         )}
         role="tab"
         data-active={isActive ? "true" : undefined}
@@ -272,7 +275,7 @@ export function NoteTabItem({ noteId, instanceId }: NoteTabItemProps) {
           <span className="overflow-hidden text-ellipsis">{label}</span>
         )}
 
-        {/* Active tab action buttons */}
+        {/* Active tab: single overflow menu button */}
         {isActive && (
           <div
             className="flex items-center gap-px shrink-0 ml-1"
@@ -282,62 +285,17 @@ export function NoteTabItem({ noteId, instanceId }: NoteTabItemProps) {
             }}
           >
             <button
-              className={cn(
-                actionBtnClass,
-                (isDirty || isSaving) && "text-amber-500",
-              )}
-              onClick={() => dispatch(saveNote(noteId))}
-              title="Save (Ctrl+S)"
-            >
-              <Save />
-            </button>
-            <button
-              className={actionBtnClass}
-              onClick={() => {
-                navigator.clipboard.writeText(content).catch(() => {});
+              className={cn(actionBtnClass, !!overflowMenuPos && "text-primary bg-accent")}
+              onClick={(e) => {
+                const rect = e.currentTarget.getBoundingClientRect();
+                setOverflowMenuPos((v) =>
+                  v ? null : { right: window.innerWidth - rect.right, top: rect.bottom + 4 },
+                );
               }}
-              title="Copy content"
+              title="More actions"
             >
-              <Copy />
+              <MoreHorizontal />
             </button>
-            <button
-              className={actionBtnClass}
-              onClick={() => setShareOpen(true)}
-              title="Share note"
-            >
-              <Share2 />
-            </button>
-            <button
-              ref={folderBtnRef}
-              className={actionBtnClass}
-              onClick={() => setShowFolderDrop((v) => !v)}
-              title="Move to folder"
-            >
-              <FolderInput />
-            </button>
-            <button
-              ref={contextBtnRef}
-              className={cn(
-                actionBtnClass,
-                contextOpen && "text-primary bg-accent",
-              )}
-              onClick={() => setContextOpen((v) => !v)}
-              title="Set context"
-            >
-              <Network />
-            </button>
-            <button
-              className={cn(actionBtnClass, "hover:text-destructive")}
-              onClick={requestDelete}
-              title="Delete"
-            >
-              <Trash2 />
-            </button>
-            <MicrophoneIconButton
-              onTranscriptionComplete={handleTranscription}
-              variant="icon-only"
-              size="sm"
-            />
           </div>
         )}
 
@@ -471,6 +429,70 @@ export function NoteTabItem({ noteId, instanceId }: NoteTabItemProps) {
                 </button>
               ),
             )}
+          </div>
+        </>
+      )}
+
+      {/* Overflow (⋯) menu */}
+      {overflowMenuPos && isActive && (
+        <>
+          <div className="fixed inset-0 z-[110]" onClick={() => setOverflowMenuPos(null)} />
+          <div
+            className="fixed z-[120] min-w-[180px] py-1 bg-card/95 backdrop-blur-2xl border border-border rounded-lg shadow-lg"
+            style={{ right: overflowMenuPos.right, top: overflowMenuPos.top }}
+          >
+            <div className="px-3 py-1 text-[0.5625rem] font-semibold uppercase tracking-wide text-muted-foreground">
+              Actions
+            </div>
+            <button
+              className={cn(menuItemClass, (isDirty || isSaving) && "text-amber-500")}
+              onClick={() => { dispatch(saveNote(noteId)); setOverflowMenuPos(null); }}
+            >
+              <Save className="w-3 h-3 shrink-0" /> Save
+              <span className="ml-auto text-[0.625rem] text-muted-foreground/60">Ctrl+S</span>
+            </button>
+            <button
+              className={menuItemClass}
+              onClick={() => { navigator.clipboard.writeText(content).catch(() => {}); setOverflowMenuPos(null); }}
+            >
+              <Copy className="w-3 h-3 shrink-0" /> Copy Content
+            </button>
+            <button
+              className={menuItemClass}
+              onClick={() => { setShareOpen(true); setOverflowMenuPos(null); }}
+            >
+              <Share2 className="w-3 h-3 shrink-0" /> Share
+            </button>
+            <button
+              className={menuItemClass}
+              onClick={() => { setShowFolderDrop((v) => !v); setOverflowMenuPos(null); }}
+            >
+              <FolderInput className="w-3 h-3 shrink-0" /> Move to Folder
+            </button>
+            <button
+              className={cn(menuItemClass, contextOpen && "text-primary")}
+              onClick={() => { setContextOpen((v) => !v); setOverflowMenuPos(null); }}
+            >
+              <Network className="w-3 h-3 shrink-0" /> Set Context
+            </button>
+            <div className={menuItemClass}>
+              <MicrophoneIconButton
+                onTranscriptionComplete={(text) => { handleTranscription(text); setOverflowMenuPos(null); }}
+                variant="icon-only"
+                size="sm"
+              />
+              <span>Dictate</span>
+            </div>
+            <div className="h-px bg-border/50 my-1" />
+            <div className="px-3 py-1 text-[0.5625rem] font-semibold uppercase tracking-wide text-muted-foreground">
+              Danger
+            </div>
+            <button
+              className={cn(menuItemClass, "text-destructive hover:bg-destructive/10")}
+              onClick={() => { requestDelete(); setOverflowMenuPos(null); }}
+            >
+              <Trash2 className="w-3 h-3 shrink-0" /> Delete Note
+            </button>
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary

**Bug fixes:**
- Active tab name disappears when many tabs overflow — idle auto-move (`moveActiveTabToFront`, fires after 1.5 s) reorders tabs without changing `activeTabId`, so scroll-into-view never ran after the move. Added `openTabs` to the scroll effect's dependency array.
- `+` (New Note) button was inside the scrollable container and scrolled off-screen when tabs overflow. Moved it before the scroll container so it stays pinned to the left edge.

**UI improvements:**
- Replace 7 inline action buttons on the active tab with a single `⋯` overflow menu, positioned `fixed` to escape the `overflow-y-hidden` clip on the tab bar.
- Inactive tabs: dimmed text (`muted-foreground/70`) with hover restore for clearer active/inactive hierarchy.
- Close button now shows/hides instantly (removed opacity transition).
- Hide horizontal scrollbar track (`scrollbar-none`) while keeping scroll functionality.

## Affected files

- `features/notes/components/NoteTabBar.tsx`
- `features/notes/components/NoteTabItem.tsx`
- `app/(a)/notes/notes.css`

## Test plan

- [ ] Open `/notes` and open enough tabs to overflow the tab bar
- [ ] Click a tab near the right end; wait ~2 s idle — active tab auto-moves to position 0 and scrolls into view (name stays visible)
- [ ] Confirm `+` button is always visible at the left regardless of scroll position
- [ ] Click `⋯` on the active tab — overflow menu appears with Save, Copy, Share, Move to Folder, Set Context, Dictate, Delete
- [ ] Confirm inactive tabs appear dimmer than the active tab
- [ ] Confirm close button appears/disappears instantly on hover
- [ ] Confirm DnD reorder still works
- [ ] Confirm split-view button still appears to the right of all tabs