### PR TITLE
fix(image-editor): inline file tree on landing + direct Save button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ public/pdfjs/
 # macOS Finder metadata
 .DS_Store
 **/.DS_Store
+.worktrees/

--- a/app/(a)/images/edit/EditLandingClient.tsx
+++ b/app/(a)/images/edit/EditLandingClient.tsx
@@ -1,17 +1,34 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { FolderOpen, Loader2 } from "lucide-react";
+import {
+  ArrowLeft,
+  ChevronRight,
+  File,
+  FileImage,
+  FolderClosed,
+  Loader2,
+  Search,
+  Upload,
+} from "lucide-react";
 import { toast } from "sonner";
 import {
   ImageAssetUploader,
   type ImageUploaderResult,
 } from "@/components/official/ImageAssetUploader";
-import { Button } from "@/components/ui/button";
 import { CloudFolders } from "@/features/files";
 import { fileHandler } from "@/features/files/handler/handler";
-import { openFilePicker } from "@/features/files/components/pickers/cloudFilesPickerOpeners";
+import { isImageMime, resolveMime } from "@/features/files";
+import type { CloudFileRecord, CloudFolderRecord } from "@/features/files";
+import { useAppDispatch, useAppSelector } from "@/lib/redux/hooks";
+import { selectActiveUserId } from "@/lib/redux/selectors/userSelectors";
+import {
+  selectAllFoldersMap,
+  selectTreeStatus,
+} from "@/features/files/redux/selectors";
+import { loadUserFileTree } from "@/features/files/redux/thunks";
+import { useFolderContents } from "@/features/files/hooks/useFolderContents";
 
 const IMAGE_EXTS = ["png", "jpg", "jpeg", "webp", "gif", "avif", "heic"];
 
@@ -22,6 +39,7 @@ interface Props {
 export default function EditLandingClient({ folder }: Props) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
+  const [activeTab, setActiveTab] = useState<"upload" | "myfiles">("upload");
 
   const goToEditor = useCallback(
     (fileId: string) => {
@@ -39,23 +57,7 @@ export default function EditLandingClient({ folder }: Props) {
     [goToEditor],
   );
 
-  const handlePickFromCloud = useCallback(async () => {
-    setBusy(true);
-    try {
-      const ids = await openFilePicker({
-        allowedExtensions: IMAGE_EXTS,
-        title: "Choose an image",
-        description: "Pick an image from your cloud files to edit.",
-      });
-      if (ids && ids[0]) {
-        goToEditor(ids[0]);
-      }
-    } finally {
-      setBusy(false);
-    }
-  }, [goToEditor]);
-
-  // Image paste (Ctrl/Cmd+V) — intercepts binary clipboard images and uploads.
+  // Ctrl/Cmd+V — intercepts binary clipboard images, uploads, routes to editor.
   useEffect(() => {
     const handler = async (e: ClipboardEvent) => {
       if (busy) return;
@@ -70,11 +72,9 @@ export default function EditLandingClient({ folder }: Props) {
           setBusy(true);
           try {
             const ext = item.type.split("/")[1]?.split("+")[0] ?? "png";
-            const file = new File(
-              [blob],
-              `pasted-${Date.now()}.${ext}`,
-              { type: item.type },
-            );
+            const file = new File([blob], `pasted-${Date.now()}.${ext}`, {
+              type: item.type,
+            });
             const normalized = await fileHandler.upload(
               { kind: "file", file },
               {
@@ -89,8 +89,7 @@ export default function EditLandingClient({ folder }: Props) {
               toast.error("Pasted image upload returned no file id.");
             }
           } catch (err) {
-            const msg = err instanceof Error ? err.message : "Paste upload failed";
-            toast.error(msg);
+            toast.error(err instanceof Error ? err.message : "Paste upload failed");
           } finally {
             setBusy(false);
           }
@@ -103,61 +102,303 @@ export default function EditLandingClient({ folder }: Props) {
   }, [busy, goToEditor]);
 
   return (
-    <div className="h-full w-full overflow-y-auto overscroll-contain flex items-start md:items-center justify-center p-3 md:p-6 bg-background">
-      <div className="w-full max-w-xl flex flex-col gap-4 md:gap-5">
-        <div className="text-center space-y-1">
-          <h2 className="text-lg font-semibold">Pick an image to edit</h2>
-          <p className="text-xs text-muted-foreground">
-            Upload, paste a URL or image, drag a file in, or open one from your
-            cloud files. We'll save it for you and jump into the editor.
-          </p>
-        </div>
-
-        <ImageAssetUploader
-          onComplete={handleUploaderResult}
-          preset="raw"
-          folder={CloudFolders.IMAGES_EDITED_SOURCES}
-          visibility="private"
-          label="Edit source"
-          allowUrlPaste
-          compact={false}
-          hideVariantBadges
-          disabled={busy}
+    <div className="h-full w-full flex flex-col bg-background overflow-hidden">
+      {/* Tab bar */}
+      <div className="flex border-b border-border shrink-0">
+        <TabButton
+          active={activeTab === "upload"}
+          onClick={() => setActiveTab("upload")}
+          icon={<Upload className="h-3.5 w-3.5" />}
+          label="Upload"
         />
+        <TabButton
+          active={activeTab === "myfiles"}
+          onClick={() => setActiveTab("myfiles")}
+          label="My Files"
+        />
+      </div>
 
-        <div className="flex items-center gap-3">
-          <div className="flex-1 h-px bg-border" />
-          <span className="text-xs text-muted-foreground">or</span>
-          <div className="flex-1 h-px bg-border" />
+      {activeTab === "upload" ? (
+        <div className="flex-1 overflow-y-auto overscroll-contain flex items-start md:items-center justify-center p-3 md:p-6">
+          <div className="w-full max-w-xl flex flex-col gap-4 md:gap-5">
+            <div className="text-center space-y-1">
+              <h2 className="text-lg font-semibold">Pick an image to edit</h2>
+              <p className="text-xs text-muted-foreground">
+                Upload, paste a URL or image, or drag a file in.
+              </p>
+            </div>
+            <ImageAssetUploader
+              onComplete={handleUploaderResult}
+              preset="raw"
+              folder={CloudFolders.IMAGES_EDITED_SOURCES}
+              visibility="private"
+              label="Edit source"
+              allowUrlPaste
+              compact={false}
+              hideVariantBadges
+              disabled={busy}
+            />
+            <p className="text-center text-[11px] text-muted-foreground">
+              Tip: paste an image with{" "}
+              <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono">
+                ⌘V
+              </kbd>{" "}
+              /{" "}
+              <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono">
+                Ctrl+V
+              </kbd>
+              .
+            </p>
+          </div>
         </div>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <FileTreePicker onSelect={goToEditor} busy={busy} />
+        </div>
+      )}
+    </div>
+  );
+}
 
-        <Button
-          variant="outline"
-          size="default"
-          onClick={() => void handlePickFromCloud()}
-          disabled={busy}
-          className="w-full justify-center gap-2"
-        >
-          {busy ? (
+// ---------------------------------------------------------------------------
+// Tab button
+// ---------------------------------------------------------------------------
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon?: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        "flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors shrink-0",
+        active
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
+      ].join(" ")}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline file tree picker
+// ---------------------------------------------------------------------------
+
+interface FileTreePickerProps {
+  onSelect: (fileId: string) => void;
+  busy: boolean;
+}
+
+function FileTreePicker({ onSelect, busy }: FileTreePickerProps) {
+  const dispatch = useAppDispatch();
+  const userId = useAppSelector(selectActiveUserId);
+  const treeStatus = useAppSelector(selectTreeStatus);
+  const foldersById = useAppSelector(selectAllFoldersMap);
+
+  const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (!userId) return;
+    if (treeStatus === "idle" || treeStatus === "error") {
+      void dispatch(loadUserFileTree({ userId }));
+    }
+  }, [userId, treeStatus, dispatch]);
+
+  const { files, folders, loading } = useFolderContents(currentFolderId);
+
+  const currentFolder = currentFolderId
+    ? (foldersById[currentFolderId] ?? null)
+    : null;
+
+  const { visibleFolders, visibleFiles } = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return { visibleFolders: folders, visibleFiles: files };
+    return {
+      visibleFolders: folders.filter((f) =>
+        f.folderName.toLowerCase().includes(q),
+      ),
+      visibleFiles: files.filter((f) =>
+        f.fileName.toLowerCase().includes(q),
+      ),
+    };
+  }, [folders, files, query]);
+
+  const isInitialLoading =
+    (treeStatus === "idle" || treeStatus === "loading") &&
+    visibleFolders.length === 0 &&
+    visibleFiles.length === 0;
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header: back + current folder name + search */}
+      <div className="px-3 py-2 border-b border-border flex items-center gap-2 shrink-0">
+        {currentFolderId ? (
+          <button
+            onClick={() =>
+              setCurrentFolderId(currentFolder?.parentId ?? null)
+            }
+            className="shrink-0 p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Back to parent folder"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+        ) : null}
+        <span className="text-sm font-medium truncate flex-1 min-w-0">
+          {currentFolder ? currentFolder.folderName : "My Files"}
+        </span>
+        <div className="relative shrink-0">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search..."
+            className="h-7 w-36 pl-7 pr-2 rounded-md border border-border bg-background text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            style={{ fontSize: "16px" }}
+          />
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto overscroll-contain">
+        {isInitialLoading ? (
+          <div className="flex items-center justify-center py-16 text-muted-foreground gap-2">
             <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <FolderOpen className="h-4 w-4" />
-          )}
-          Pick from your cloud files
-        </Button>
-
-        <p className="text-center text-[11px] text-muted-foreground">
-          Tip: paste an image with{" "}
-          <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono">
-            ⌘V
-          </kbd>{" "}
-          /{" "}
-          <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono">
-            Ctrl+V
-          </kbd>
-          .
-        </p>
+            <span className="text-sm">Loading your files…</span>
+          </div>
+        ) : visibleFolders.length === 0 && visibleFiles.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center px-6 gap-3">
+            <FolderClosed className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              {query
+                ? "No matches in this folder"
+                : currentFolderId
+                  ? "This folder is empty"
+                  : "Your cloud is empty — upload something first"}
+            </p>
+            {currentFolderId ? (
+              <button
+                onClick={() =>
+                  setCurrentFolderId(currentFolder?.parentId ?? null)
+                }
+                className="text-xs text-primary hover:underline"
+              >
+                Go back
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <ul className="py-1">
+            {visibleFolders.map((f) => (
+              <FolderRow
+                key={f.id}
+                folder={f}
+                onOpen={setCurrentFolderId}
+              />
+            ))}
+            {visibleFiles.map((f) => (
+              <FileRow
+                key={f.id}
+                file={f}
+                onSelect={onSelect}
+                disabled={busy || loading}
+              />
+            ))}
+          </ul>
+        )}
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row components
+// ---------------------------------------------------------------------------
+
+function FolderRow({
+  folder,
+  onOpen,
+}: {
+  folder: CloudFolderRecord;
+  onOpen: (id: string) => void;
+}) {
+  return (
+    <li>
+      <button
+        onClick={() => onOpen(folder.id)}
+        className="w-full flex items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-accent transition-colors text-left"
+      >
+        <FolderClosed className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="flex-1 truncate">{folder.folderName}</span>
+        <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      </button>
+    </li>
+  );
+}
+
+function FileRow({
+  file,
+  onSelect,
+  disabled,
+}: {
+  file: CloudFileRecord;
+  onSelect: (fileId: string) => void;
+  disabled: boolean;
+}) {
+  const mime = resolveMime(file.mimeType, file.fileName);
+  const isImage = isImageMime(mime);
+  const ext = (file.fileName.split(".").pop() ?? "").toLowerCase();
+  const isEditable = isImage && IMAGE_EXTS.includes(ext);
+
+  return (
+    <li>
+      <button
+        onClick={() => {
+          if (isEditable && !disabled) onSelect(file.id);
+        }}
+        disabled={!isEditable || disabled}
+        title={
+          isEditable
+            ? file.fileName
+            : `${file.fileName} — not a supported image type`
+        }
+        className={[
+          "w-full flex items-center gap-2.5 px-3 py-1.5 text-sm text-left transition-colors",
+          isEditable && !disabled
+            ? "hover:bg-accent cursor-pointer"
+            : "opacity-40 cursor-not-allowed",
+        ].join(" ")}
+      >
+        {/* Thumbnail */}
+        {isImage && file.publicUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={file.publicUrl}
+            alt=""
+            className="h-7 w-7 shrink-0 rounded object-cover bg-muted"
+          />
+        ) : (
+          <div className="h-7 w-7 shrink-0 rounded bg-muted flex items-center justify-center">
+            {isImage ? (
+              <FileImage className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <File className="h-4 w-4 text-muted-foreground" />
+            )}
+          </div>
+        )}
+        <span className="flex-1 truncate">{file.fileName}</span>
+      </button>
+    </li>
   );
 }

--- a/app/(a)/images/edit/EditLandingClient.tsx
+++ b/app/(a)/images/edit/EditLandingClient.tsx
@@ -211,7 +211,7 @@ function FileTreePicker({ onSelect, busy }: FileTreePickerProps) {
 
   useEffect(() => {
     if (!userId) return;
-    if (treeStatus === "idle" || treeStatus === "error") {
+    if (treeStatus === "idle") {
       void dispatch(loadUserFileTree({ userId }));
     }
   }, [userId, treeStatus, dispatch]);

--- a/features/image-studio/modes/edit/EditModeShell.tsx
+++ b/features/image-studio/modes/edit/EditModeShell.tsx
@@ -593,41 +593,41 @@ export function EditModeShell({
             <TooltipContent>Generate Web / Social / Email / Avatar / Favicon variants</TooltipContent>
           </Tooltip>
 
-          {/* Save dropdown */}
+          {/* Save — direct button */}
           <Tooltip>
             <TooltipTrigger asChild>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="default"
-                    size="sm"
-                    className="h-7 shrink-0 gap-1 text-xs"
-                    disabled={saving}
-                  >
-                    {saving ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Save className="h-3.5 w-3.5" />
-                    )}
-                    Save
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-56">
-                  <DropdownMenuItem
-                    onClick={handleHeaderSave}
-                    disabled={!effectiveCloudFileId}
-                  >
-                    <Save className="h-3.5 w-3.5 mr-2" />
-                    Save as new version
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={handleSaveAsDuplicate}>
-                    <Copy className="h-3.5 w-3.5 mr-2" />
-                    Save as duplicate
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <Button
+                variant="default"
+                size="sm"
+                className="h-7 shrink-0 gap-1 text-xs"
+                onClick={handleHeaderSave}
+                disabled={saving || !effectiveCloudFileId}
+              >
+                {saving ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" />
+                )}
+                Save
+              </Button>
             </TooltipTrigger>
-            <TooltipContent>Save edits — choose new version or duplicate</TooltipContent>
+            <TooltipContent>Save as new version</TooltipContent>
+          </Tooltip>
+
+          {/* Duplicate — ghost icon button */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                onClick={handleSaveAsDuplicate}
+                disabled={saving}
+              >
+                <Copy className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Save as duplicate (new file)</TooltipContent>
           </Tooltip>
 
           {/* History rail toggle — subtle "selected" state via accent. */}


### PR DESCRIPTION
## Summary

- Replace the cloud file picker overlay on `/images/edit` with an inline tabbed layout (Upload | My Files), letting users click straight into the editor without a modal
- Split the Save dropdown in the editor header into a direct **Save** button + a ghost **Duplicate** icon button — one click instead of two for the most common action
- Back button already fixed to always return to `/images/edit` (no `router.back()` escape hatch)

## Test plan

- [ ] Go to `/images/edit` — confirm two tabs: Upload and My Files
- [ ] My Files tab: folders navigate in-place, images are clickable and route to `/images/edit/[id]`, non-image files are dimmed/disabled
- [ ] Search filters folder and file names inline
- [ ] Upload tab: uploader and Ctrl/Cmd+V paste still work
- [ ] In the editor, Save button fires immediately (no dropdown), Duplicate icon button saves a new file
- [ ] Back chevron returns to `/images/edit` regardless of how you arrived