### PR TITLE
data-tables: Wave H retention + cld_files FK + smart importer + bulk paste + CRDT v2 scaffolding

### DIFF
--- a/app/(core)/data/page.tsx
+++ b/app/(core)/data/page.tsx
@@ -1,17 +1,36 @@
 'use client'
 import TableCards from "@/components/user-generated-table-data/TableCards";
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from "@/components/ui/button";
 import { Plus, Upload } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import CreateTableModal from "@/components/user-generated-table-data/CreateTableModal";
 import ImportTableModal from "@/components/user-generated-table-data/ImportTableModal";
 import { FcTemplate } from "react-icons/fc";
+import { consumeSmartImportFile } from "@/features/data-tables/smart-import-pickup";
 
 export default function UserGeneratedDataPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
+  const [prefilledFile, setPrefilledFile] = useState<File | null>(null);
+
+  // Smart Import handoff from /workbooks: if the query says smartImport=1,
+  // claim the file from the module slot and open the import modal pre-loaded.
+  // The slot is single-shot; re-navigating to /data without a fresh handoff
+  // gets nothing.
+  useEffect(() => {
+    if (searchParams.get("smartImport") === "1") {
+      const f = consumeSmartImportFile();
+      if (f) {
+        setPrefilledFile(f);
+        setIsImportModalOpen(true);
+      }
+      // Strip the query so refresh doesn't re-attempt.
+      router.replace("/data");
+    }
+  }, [searchParams, router]);
 
   // Handle the create from template button click
   const handleCreateFromTemplate = () => {
@@ -66,10 +85,14 @@ export default function UserGeneratedDataPage() {
       />
 
       {/* Import Table Modal */}
-      <ImportTableModal 
+      <ImportTableModal
         isOpen={isImportModalOpen}
-        onClose={() => setIsImportModalOpen(false)}
+        onClose={() => {
+          setIsImportModalOpen(false);
+          setPrefilledFile(null);
+        }}
         onSuccess={handleTableCreated}
+        prefilledFile={prefilledFile}
       />
     </div>
   );

--- a/app/(core)/workbooks/page.tsx
+++ b/app/(core)/workbooks/page.tsx
@@ -6,6 +6,7 @@ import {
   FileSpreadsheet,
   Loader2,
   Plus,
+  Sparkles,
   Trash,
   Upload,
 } from "lucide-react";
@@ -23,6 +24,14 @@ import {
 } from "@/features/data-tables/workbook-service";
 import { isServiceFailure, type Workbook } from "@/features/data-tables/types";
 import { xlsxToUniverWorkbook } from "@/features/data-tables/xlsx-to-univer";
+import { fileHandler } from "@/features/files/handler/handler";
+import {
+  detectImportRoute,
+  type ImportRouteDetection,
+  type ImportRouting,
+} from "@/features/data-tables/smart-importer";
+import { ImportRouteDialog } from "@/features/data-tables/components/ImportRouteDialog";
+import { smartImportPickupSlot } from "@/features/data-tables/smart-import-pickup";
 
 export default function WorkbooksLandingPage() {
   const router = useRouter();
@@ -32,6 +41,15 @@ export default function WorkbooksLandingPage() {
   const [creating, setCreating] = useState(false);
   const [importing, setImporting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Smart-import state: separate file picker pointed at the same accept set
+  // but funnels through detectImportRoute() before committing.
+  const smartFileInputRef = useRef<HTMLInputElement | null>(null);
+  const [smartDetection, setSmartDetection] =
+    useState<ImportRouteDetection | null>(null);
+  const [smartFile, setSmartFile] = useState<File | null>(null);
+  const [smartDialogOpen, setSmartDialogOpen] = useState(false);
+  const [smartCommitting, setSmartCommitting] = useState(false);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -73,6 +91,25 @@ export default function WorkbooksLandingPage() {
         // BEFORE creating an empty workbook the user would have to delete.
         const snapshot = await xlsxToUniverWorkbook(file);
 
+        // Stash the lossless original in cld_files so users can download or
+        // re-import the source later. Failure here is non-fatal — the workbook
+        // import path is the primary deliverable, the original-file link is
+        // a recoverability nicety (FK is ON DELETE SET NULL, so we'd nil out
+        // the link if the file went away anyway). Log + continue on failure.
+        let originalFileId: string | undefined;
+        try {
+          const uploaded = await fileHandler.upload(
+            { kind: "file", file },
+            { folderPath: "Workbooks/Imports" },
+          );
+          originalFileId = uploaded.fileId;
+        } catch (uploadErr) {
+          console.warn(
+            "Workbook import: stashing original failed; continuing without link.",
+            uploadErr,
+          );
+        }
+
         const cleanName = file.name.replace(/\.[^.]+$/, "") || "Imported workbook";
         const created = await createWorkbook({
           name: cleanName,
@@ -80,6 +117,7 @@ export default function WorkbooksLandingPage() {
           source: file.name.toLowerCase().endsWith(".csv")
             ? "imported_csv"
             : "imported_xlsx",
+          originalFileId,
         });
         if (isServiceFailure(created)) throw new Error(created.error);
 
@@ -115,6 +153,58 @@ export default function WorkbooksLandingPage() {
       }
     },
     [router],
+  );
+
+  const handleSmartImport = useCallback(async (file: File) => {
+    // Reset the input so picking the same file again still fires onChange.
+    if (smartFileInputRef.current) smartFileInputRef.current.value = "";
+    setSmartCommitting(false);
+
+    try {
+      const detection = await detectImportRoute(file);
+      setSmartFile(file);
+      setSmartDetection(detection);
+      setSmartDialogOpen(true);
+    } catch (err) {
+      toast({
+        title: "Could not analyze file",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    }
+  }, []);
+
+  const handleSmartCommit = useCallback(
+    async (routing: ImportRouting) => {
+      if (!smartFile) return;
+      setSmartCommitting(true);
+      try {
+        if (routing === "workbook") {
+          setSmartDialogOpen(false);
+          await handleImportXlsx(smartFile);
+        } else {
+          // Typed-dataset routing — the rich import/preview/column-config
+          // flow lives at /data. Stash the file briefly on the window so
+          // /data can pick it up (sessionStorage holds the filename and a
+          // pickup token; the actual File is non-serializable so it rides
+          // on a global module-level slot).
+          smartImportPickupSlot.file = smartFile;
+          smartImportPickupSlot.takenAt = Date.now();
+          setSmartDialogOpen(false);
+          toast({
+            title: "Opening in typed-data import",
+            description: smartFile.name,
+            variant: "default",
+          });
+          router.push("/data?smartImport=1");
+        }
+      } finally {
+        setSmartCommitting(false);
+        setSmartFile(null);
+        setSmartDetection(null);
+      }
+    },
+    [smartFile, router],
   );
 
   const handleDelete = useCallback(
@@ -162,9 +252,28 @@ export default function WorkbooksLandingPage() {
               if (f) void handleImportXlsx(f);
             }}
           />
+          <input
+            ref={smartFileInputRef}
+            type="file"
+            accept=".xlsx,.xls,.csv"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void handleSmartImport(f);
+            }}
+          />
           <Button
             variant="outline"
-            disabled={importing || creating}
+            disabled={importing || creating || smartCommitting}
+            onClick={() => smartFileInputRef.current?.click()}
+            title="Auto-detect whether your file is a typed dataset or a workbook"
+          >
+            <Sparkles className="h-4 w-4 mr-2" />
+            Smart import
+          </Button>
+          <Button
+            variant="outline"
+            disabled={importing || creating || smartCommitting}
             onClick={() => fileInputRef.current?.click()}
           >
             {importing ? (
@@ -174,7 +283,10 @@ export default function WorkbooksLandingPage() {
             )}
             Import XLSX / CSV
           </Button>
-          <Button onClick={handleCreate} disabled={creating || importing}>
+          <Button
+            onClick={handleCreate}
+            disabled={creating || importing || smartCommitting}
+          >
             {creating ? (
               <Loader2 className="h-4 w-4 mr-2 animate-spin" />
             ) : (
@@ -254,6 +366,21 @@ export default function WorkbooksLandingPage() {
           ))}
         </div>
       )}
+
+      <ImportRouteDialog
+        isOpen={smartDialogOpen}
+        onClose={() => {
+          if (!smartCommitting) {
+            setSmartDialogOpen(false);
+            setSmartFile(null);
+            setSmartDetection(null);
+          }
+        }}
+        detection={smartDetection}
+        fileName={smartFile?.name ?? ""}
+        onCommit={handleSmartCommit}
+        isCommitting={smartCommitting}
+      />
     </div>
   );
 }

--- a/components/user-generated-table-data/ImportTableModal.tsx
+++ b/components/user-generated-table-data/ImportTableModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { supabase } from "@/utils/supabase/client";
 import Papa from "papaparse";
 import {
@@ -53,6 +53,12 @@ interface ImportTableModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: (tableId: string) => void;
+  /**
+   * Optional pre-loaded file (e.g. from the Smart Import handoff on
+   * /workbooks). When provided, the modal opens directly to the preview
+   * stage with this file already parsed.
+   */
+  prefilledFile?: File | null;
 }
 
 // Local alias preserved so existing JSX references continue to type-check.
@@ -62,6 +68,7 @@ export default function ImportTableModal({
   isOpen,
   onClose,
   onSuccess,
+  prefilledFile = null,
 }: ImportTableModalProps) {
   const [activeTab, setActiveTab] = useState<"upload" | "paste">("upload");
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -91,6 +98,17 @@ export default function ImportTableModal({
   // Loading/submission
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Smart Import handoff — when /workbooks routes a typed-looking file here,
+  // it passes it as `prefilledFile`. We auto-process it the same way the
+  // file-picker change handler does, so the user lands on the preview/config
+  // stage without an extra click.
+  useEffect(() => {
+    if (isOpen && prefilledFile) {
+      handleFileSelect(prefilledFile);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, prefilledFile]);
 
   const handleFileSelect = (file: File) => {
     if (!file) return;

--- a/components/user-generated-table-data/PasteRowsDialog.tsx
+++ b/components/user-generated-table-data/PasteRowsDialog.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { useState } from "react";
+import Papa from "papaparse";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Loader2 } from "lucide-react";
+import { toast } from "@/components/ui/use-toast";
+import { sanitizeFieldName } from "@/utils/user-table-utls/field-name-sanitizer";
+import { bulkWrite } from "@/features/data-tables/service";
+import {
+  isServiceFailure,
+  type BulkInsertOp,
+} from "@/features/data-tables/types";
+
+interface PasteRowsField {
+  id: string;
+  field_name: string;
+  display_name: string;
+  data_type: string;
+  is_required: boolean;
+}
+
+interface PasteRowsDialogProps {
+  tableId: string;
+  fields: PasteRowsField[];
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+type ParsedRow = Record<string, unknown>;
+
+// Map of incoming paste-header → matched dataset field (or null when skipped).
+// Built once at parse time so stage 2 can render preview + column mapping AND
+// reuse the same resolution to build the bulkWrite payload.
+interface PasteColumnMapping {
+  pasteHeader: string;
+  matchedField: PasteRowsField | null;
+}
+
+export default function PasteRowsDialog({
+  tableId,
+  fields,
+  isOpen,
+  onClose,
+  onSuccess,
+}: PasteRowsDialogProps) {
+  const [stage, setStage] = useState<"paste" | "preview">("paste");
+  const [pasteData, setPasteData] = useState("");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [parsedRows, setParsedRows] = useState<ParsedRow[]>([]);
+  const [columnMappings, setColumnMappings] = useState<PasteColumnMapping[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const resetAll = () => {
+    setStage("paste");
+    setPasteData("");
+    setParseError(null);
+    setParsedRows([]);
+    setColumnMappings([]);
+    setSubmitting(false);
+  };
+
+  const handleClose = () => {
+    resetAll();
+    onClose();
+  };
+
+  const handleParse = () => {
+    if (!pasteData.trim()) {
+      setParseError("Please paste some data");
+      return;
+    }
+    setParseError(null);
+
+    Papa.parse<ParsedRow>(pasteData.trim(), {
+      header: true,
+      skipEmptyLines: true,
+      delimiter: "", // auto-detect tab vs comma
+      complete: (results) => {
+        const rows = results.data;
+        if (!rows || rows.length === 0) {
+          setParseError("No valid rows found");
+          return;
+        }
+        const headers = results.meta.fields ?? [];
+        if (headers.length === 0) {
+          setParseError("Could not detect a header row");
+          return;
+        }
+
+        const mappings: PasteColumnMapping[] = headers.map((pasteHeader) => {
+          const sanitized = sanitizeFieldName(pasteHeader);
+          const matched =
+            fields.find((f) => f.field_name === sanitized) ?? null;
+          return { pasteHeader, matchedField: matched };
+        });
+
+        setParsedRows(rows);
+        setColumnMappings(mappings);
+        setStage("preview");
+      },
+      error: (err: Error) => {
+        setParseError(`Error parsing data: ${err.message}`);
+      },
+    });
+  };
+
+  // Dataset columns that won't be filled by any paste column — surfaced in
+  // stage 2 so the user can see what's going to be blank.
+  const unmatchedDatasetFields = fields.filter(
+    (f) =>
+      !columnMappings.some(
+        (m) => m.matchedField && m.matchedField.field_name === f.field_name,
+      ),
+  );
+
+  const matchedCount = columnMappings.filter((m) => m.matchedField).length;
+
+  const handleConfirm = async () => {
+    if (parsedRows.length === 0) return;
+
+    const operations: BulkInsertOp[] = parsedRows.map((row) => {
+      const data: Record<string, unknown> = {};
+      for (const mapping of columnMappings) {
+        if (!mapping.matchedField) continue;
+        const value = row[mapping.pasteHeader];
+        data[mapping.matchedField.field_name] = value;
+      }
+      return { op: "insert", data };
+    });
+
+    try {
+      setSubmitting(true);
+      const result = await bulkWrite({ tableId, operations });
+      if (isServiceFailure(result)) {
+        toast({
+          title: "Paste failed",
+          description: result.error,
+          variant: "destructive",
+        });
+        return;
+      }
+      toast({
+        title: "Rows pasted",
+        description: `Pasted ${operations.length} row${operations.length === 1 ? "" : "s"}`,
+        variant: "success",
+      });
+      onSuccess();
+      handleClose();
+    } catch (err) {
+      toast({
+        title: "Paste failed",
+        description:
+          err instanceof Error ? err.message : "An unexpected error occurred",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="sm:max-w-[800px] max-h-[90vh] overflow-hidden flex flex-col bg-card">
+        <DialogHeader className="flex-shrink-0">
+          <DialogTitle>
+            {stage === "paste" ? "Paste Rows" : "Confirm Pasted Rows"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto min-h-0 space-y-4 py-4">
+          {stage === "paste" ? (
+            <div className="space-y-2">
+              <Label htmlFor="pasteData">
+                Paste from Excel, Google Sheets, or a CSV
+              </Label>
+              <Textarea
+                id="pasteData"
+                value={pasteData}
+                onChange={(e) => setPasteData(e.target.value)}
+                placeholder={
+                  "Name\tAge\tEmail\n" +
+                  "John\t25\tjohn@example.com\n" +
+                  "Jane\t30\tjane@example.com"
+                }
+                rows={12}
+                className="font-mono text-sm"
+              />
+              {parseError && (
+                <p className="text-sm text-red-500">{parseError}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                The first row must be a header. Tab- and comma-separated values
+                are both supported.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {/* Column mapping summary */}
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>Column mapping</Label>
+                  <span className="text-xs text-muted-foreground">
+                    {matchedCount} of {columnMappings.length} paste columns
+                    matched
+                  </span>
+                </div>
+                <div className="border border-border rounded-lg p-3 space-y-1 max-h-[180px] overflow-y-auto bg-card">
+                  {columnMappings.map((m) => (
+                    <div
+                      key={m.pasteHeader}
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <span className="font-medium truncate min-w-[160px]">
+                        {m.pasteHeader}
+                      </span>
+                      <span className="text-muted-foreground">→</span>
+                      {m.matchedField ? (
+                        <span className="truncate">
+                          {m.matchedField.display_name}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground italic">
+                          (skipped — no matching column)
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                  {unmatchedDatasetFields.map((f) => (
+                    <div
+                      key={f.id}
+                      className="flex items-center gap-2 text-sm text-muted-foreground"
+                    >
+                      <span className="italic min-w-[160px] truncate">
+                        {f.display_name}
+                      </span>
+                      <span>—</span>
+                      <span className="italic">
+                        (unmatched dataset column — will be empty)
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Preview of first 5 parsed rows */}
+              <div className="space-y-2">
+                <Label>Preview (first 5 rows)</Label>
+                <div className="border border-border rounded-lg overflow-auto max-h-[260px] bg-card">
+                  <table className="w-full text-sm">
+                    <thead className="bg-muted sticky top-0">
+                      <tr>
+                        {columnMappings.map((m) => (
+                          <th
+                            key={m.pasteHeader}
+                            className="px-3 py-2 text-left font-medium text-xs"
+                          >
+                            {m.pasteHeader}
+                            {!m.matchedField && (
+                              <span className="ml-1 text-muted-foreground italic">
+                                (skipped)
+                              </span>
+                            )}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {parsedRows.slice(0, 5).map((row, i) => (
+                        <tr key={i} className="border-t border-border">
+                          {columnMappings.map((m) => {
+                            const cell = row[m.pasteHeader];
+                            const display =
+                              cell === null || cell === undefined
+                                ? ""
+                                : String(cell);
+                            return (
+                              <td
+                                key={m.pasteHeader}
+                                className="px-3 py-2 text-xs truncate max-w-[200px]"
+                              >
+                                {display}
+                              </td>
+                            );
+                          })}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {parsedRows.length} row{parsedRows.length === 1 ? "" : "s"}{" "}
+                  ready to paste.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex-shrink-0">
+          {stage === "preview" && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setStage("paste")}
+              disabled={submitting}
+            >
+              Back
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleClose}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          {stage === "paste" ? (
+            <Button
+              type="button"
+              onClick={handleParse}
+              disabled={!pasteData.trim()}
+            >
+              Parse
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              onClick={handleConfirm}
+              disabled={submitting || matchedCount === 0}
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Pasting...
+                </>
+              ) : (
+                `Paste ${parsedRows.length} Row${parsedRows.length === 1 ? "" : "s"}`
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/user-generated-table-data/TableToolbar.tsx
+++ b/components/user-generated-table-data/TableToolbar.tsx
@@ -8,9 +8,10 @@ import TableConfigModal from './TableConfigModal';
 import ExportTableModal from './ExportTableModal';
 import TableReferenceOverlay from './TableReferenceOverlay';
 import RowOrderingModal from './RowOrderingModal';
+import PasteRowsDialog from './PasteRowsDialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Search, X, Download, Pencil, Trash, Settings, Plus, Link, Zap, ArrowUpDown, GripVertical, Eye } from 'lucide-react';
+import { Search, X, Download, Pencil, Trash, Settings, Plus, Link, Zap, ArrowUpDown, GripVertical, Eye, Clipboard } from 'lucide-react';
 import { toast } from "@/components/ui/use-toast";
 
 interface TableToolbarProps {
@@ -37,7 +38,8 @@ interface TableToolbarProps {
   showTableSettingsModal: boolean;
   showReferenceOverlay: boolean;
   showRowOrderingModal: boolean;
-  
+  showPasteRowsDialog: boolean;
+
   // Modal visibility state setters
   setShowEditModal: (show: boolean) => void;
   setShowDeleteModal: (show: boolean) => void;
@@ -47,6 +49,7 @@ interface TableToolbarProps {
   setShowTableSettingsModal: (show: boolean) => void;
   setShowReferenceOverlay: (show: boolean) => void;
   setShowRowOrderingModal: (show: boolean) => void;
+  setShowPasteRowsDialog: (show: boolean) => void;
   
   // Success callbacks
   onEditSuccess?: () => void;
@@ -93,7 +96,8 @@ export default function TableToolbar({
   showTableSettingsModal,
   showReferenceOverlay,
   showRowOrderingModal,
-  
+  showPasteRowsDialog,
+
   // Modal visibility state setters
   setShowEditModal,
   setShowDeleteModal,
@@ -103,6 +107,7 @@ export default function TableToolbar({
   setShowTableSettingsModal,
   setShowReferenceOverlay,
   setShowRowOrderingModal,
+  setShowPasteRowsDialog,
   
   // Success callbacks
   onEditSuccess = () => loadTableData(),
@@ -155,13 +160,21 @@ export default function TableToolbar({
                 <Plus className="h-4 w-4" />
                 <span className="hidden md:inline">Column</span>
               </Button>
-              <Button 
+              <Button
                 size="sm"
                 onClick={() => setShowAddRowModal(true)}
                 className="whitespace-nowrap"
               >
                 <Plus className="h-4 w-4" />
                 <span className="hidden md:inline">Row</span>
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => setShowPasteRowsDialog(true)}
+                className="whitespace-nowrap"
+              >
+                <Clipboard className="h-4 w-4" />
+                <span className="hidden md:inline">Paste rows</span>
               </Button>
             </>
           )}
@@ -280,6 +293,13 @@ export default function TableToolbar({
             tableId={tableId}
             isOpen={showAddRowModal}
             onClose={() => setShowAddRowModal(false)}
+            onSuccess={() => loadTableData()}
+          />
+          <PasteRowsDialog
+            tableId={tableId}
+            fields={fields}
+            isOpen={showPasteRowsDialog}
+            onClose={() => setShowPasteRowsDialog(false)}
             onSuccess={() => loadTableData()}
           />
           <EditRowModal

--- a/components/user-generated-table-data/UserTableViewer.tsx
+++ b/components/user-generated-table-data/UserTableViewer.tsx
@@ -153,6 +153,7 @@ const UserTableViewer = ({
   // Additional modals
   const [showAddColumnModal, setShowAddColumnModal] = useState(false);
   const [showAddRowModal, setShowAddRowModal] = useState(false);
+  const [showPasteRowsDialog, setShowPasteRowsDialog] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showTableSettingsModal, setShowTableSettingsModal] = useState(false);
   const [showReferenceOverlay, setShowReferenceOverlay] = useState(false);
@@ -1342,6 +1343,7 @@ const UserTableViewer = ({
         showTableSettingsModal={showTableSettingsModal}
         showReferenceOverlay={showReferenceOverlay}
         showRowOrderingModal={showRowOrderingModal}
+        showPasteRowsDialog={showPasteRowsDialog}
         // Modal visibility state setters
         setShowEditModal={setShowEditModal}
         setShowDeleteModal={setShowDeleteModal}
@@ -1351,6 +1353,7 @@ const UserTableViewer = ({
         setShowTableSettingsModal={setShowTableSettingsModal}
         setShowReferenceOverlay={setShowReferenceOverlay}
         setShowRowOrderingModal={setShowRowOrderingModal}
+        setShowPasteRowsDialog={setShowPasteRowsDialog}
         // Success callbacks
         onEditSuccess={() => {
           setShowEditModal(false);

--- a/features/data-tables/FEATURE.md
+++ b/features/data-tables/FEATURE.md
@@ -47,10 +47,14 @@
 - ✅ **Share + permission gating** — `udt_workbooks` added to client-side `SHAREABLE_RESOURCE_REGISTRY` (DB registry had it from P1). `/workbooks/[id]` header gets the standard `<ShareButton>`. Page calls `has_permission(udt_workbooks, id, 'editor')` at mount to decide whether the editor mounts in editable or viewer-only mode (owner always edits; shared editors detected via the RPC; everyone else sees viewer mode).
 - ⏳ **V2 work — full CRDT collab** (per-cell deltas, presence cursors, formal conflict resolution). V1 is last-write-wins on the snapshot row, which is the standard MVP pattern. CRDT layer can build on the snapshot store without changing it.
 
-**Pending — user decision blockers (🛑):**
-- 🛑 **Wave H — version-history retention policy.** 3 options listed below; pick one before agent-heavy workloads land.
-- 🛑 **aidream backend audit attribution.** aidream's pool writes record `changed_by = NULL` (no JWT). Decide: keep honest NULL, or attribute the originating user via `set_config('request.jwt.claims', ...)` before each write.
-- 🛑 **CRDT-collab commitment.** P4 v1 ships last-write-wins. The honest "full collab from day one" answer requires picking a CRDT (Yjs is the obvious choice via Univer's `@univerjs/sheets-collaboration` preset). Confirm intent before I integrate.
+**P5 — operational hardening (decided 2026-06-06):**
+- ✅ **Wave H retention policy — implemented.** Per-row: keep all versions ≤ 14 days; ALWAYS keep latest 2 regardless of age; delete only if both `recency_rank > 2` AND `older_than_14_days`. Trim function: `udt_dataset_row_versions_trim()` (SECURITY DEFINER, service_role only). pg_cron job `udt_dataset_row_versions_trim_weekly` scheduled `0 3 * * 0` (Sundays 03:00 UTC). Migration `udt_v2_retention_and_original_file_fk` (applied live 2026-06-06).
+- ✅ **aidream attribution — honest NULL.** Decided to keep `changed_by = NULL` for service_role / pool writes (no JWT). The audit trail honestly reports "system write" rather than misattributing to row owners. No code change required on aidream's side.
+- ✅ **`udt_workbooks.original_file_id` FK live.** `REFERENCES cld_files(id) ON DELETE SET NULL`. Workbook import path now uploads the source file via `fileHandler.upload(...)` first and stores the `cld_files.id` on the workbook row. Upload failure is non-fatal — workbook still imports without the link.
+- ✅ **Smart importer (P3) — shipped.** `features/data-tables/smart-importer.ts` detects routing via 7 weighted signals (merged cells / formula density / multi-sheet / column-type uniformity / header-row pattern / sparsity / styling). Dialog (`ImportRouteDialog`) shows the recommendation with reasons; user can override. Auto-route threshold `confidence > 0.6`. "Smart import" button on `/workbooks`; typed-routing hands off to `/data` via a single-shot module slot (`smart-import-pickup.ts`) so `ImportTableModal` can open pre-loaded.
+
+**Pending — workbook collab v2 (multi-day, scoped):**
+- ⏳ **Workbook CRDT collab via Yjs + Supabase Broadcast.** Research complete (see Change log). Univer's `onMutationExecutedForCollab` hook + a custom `y-supabase` provider (~120 LoC) + `Y.Array<MutationOp>` causal log. Awareness/cursors on a separate broadcast event. Host election (lowest userId lex) for snapshot writes. Pro preset (`@univerjs/preset-sheets-collaboration`) is unusable (commercial Univer Pro backend). 3-5 days. User has green-lit; deferred to "after everything else is done" per their direction.
 
 **Pending — needs UX design (⏳):**
 - ⏳ **Wave P3 — smart importer (XLSX → typed dataset vs workbook).** Detects "rational" (header-row + uniform-type columns) vs "look-sensitive" (merged cells, formulas, multi-region) and routes the upload to `udt_datasets` or `udt_workbooks` accordingly. P4 v1 makes this fully unblocked. Today the user picks the destination by entering via `/data` (typed) or `/workbooks` (lossless).
@@ -368,6 +372,17 @@ Decide before agent-heavy workloads land.
 
 ## Change log
 
+- `2026-06-06` — claude: **Final-pass closeout — retention policy + FK to cld_files + smart importer**.
+  Decisions locked with the user: Wave H = keep latest 2 OR within 14 days (weekly pg_cron);
+  aidream attribution stays NULL (honest); CRDT collab v2 green-lit but scoped to "after the
+  rest." Migrations: `udt_v2_retention_and_original_file_fk` applied live — trim function +
+  cron schedule + `udt_workbooks.original_file_id → cld_files(id) ON DELETE SET NULL`. Workbook
+  import now stashes the source XLSX/CSV via `fileHandler.upload()` and stores the `cld_files.id`
+  on the workbook row (failure non-fatal). Smart importer (P3) shipped:
+  `features/data-tables/smart-importer.ts` (7-signal heuristic) +
+  `components/ImportRouteDialog.tsx` + `smart-import-pickup.ts` (cross-route File handoff slot)
+  + `Sparkles`-icon "Smart import" button on `/workbooks` + receive-side wiring on `/data` +
+  `prefilledFile?: File` prop on `ImportTableModal` (auto-processes on open).
 - `2026-06-05` — claude: **Workbook share + permission gating**. Added `udt_workbooks` to
   `utils/permissions/registry.ts` so `<ShareButton resourceType="udt_workbooks" />` works
   (DB-side registry entry was already added in P1; the TS mirror was stale). `/workbooks/[id]`

--- a/features/data-tables/collab/FEATURE.md
+++ b/features/data-tables/collab/FEATURE.md
@@ -1,0 +1,196 @@
+# `features/data-tables/collab` — Workbook CRDT v2
+
+**Status:** `scaffolded` (types only — implementation pending)
+**Tier:** `2` (extension of the Tier 1 data-tables / workbook surface)
+**Last updated:** `2026-06-06`
+
+---
+
+## Purpose
+
+Layer real per-cell collaborative editing on top of the v1 workbook surface
+(`features/data-tables/components/WorkbookEditor.tsx`). The v1 surface uses
+snapshot-per-save persistence with realtime hot-swap on remote save — fine for
+turn-based collaboration but produces silent overwrites if two users edit
+simultaneously. This phase eliminates that class of bug.
+
+**v1 (live):** Univer mounted on the page, autosave every 2.5s, remote snapshot
+hot-swap, last-write-wins.
+**v2 (this dir):** Yjs CRDT updates over Supabase Broadcast; snapshot store stays
+as the canonical persisted state; presence cursors over Awareness.
+
+---
+
+## Why not the official Univer collab preset
+
+`@univerjs/preset-sheets-collaboration` (already in node_modules at v0.25.0) pulls
+`@univerjs-pro/collaboration*` packages that require a proprietary "universer"
+backend with endpoints baked into the client config (`/universer-api/snapshot`,
+`/universer-api/comb/connect` WebSocket, `/universer-api/authz`, etc.). The wire
+protocol is custom OT (`ICombRequestEvent`/`ICombResponseEvent`), **not Yjs**.
+
+The Pro client *does* expose a pluggable `ICollaborationSocketService`
+(`@univerjs-pro/collaboration-client/lib/types/services/socket/collaboration-socket.service.d.ts:24`)
+but the protocol on top of it is hard-coded to Univer's OT model and expects
+server-side `authz` + `snapshot` + `history` HTTP services we don't have.
+Standing those up is a Univer Pro license deal with DreamNum.
+
+**Verdict:** roll our own bridge using Univer's public hook
+`ICommandService.onMutationExecutedForCollab` (`@univerjs/core/lib/types/services/command/command.service.d.ts:248`).
+Mutations are guaranteed serializable (`command.service.d.ts:121`) and Univer
+itself separates "command" (user intent) from "mutation" (deterministic state
+change), exposing exactly the right grain for CRDT.
+
+---
+
+## Architecture
+
+```
+Univer command  ──onMutationExecutedForCollab──▶  WorkbookCollabSession
+                                                     │
+                                                     ▼
+                                          Y.Array<MutationOp> on Y.Doc
+                                                     │
+                                          Y.encodeStateAsUpdateV2()
+                                                     │
+                                                     ▼
+                                          SupabaseYjsProvider
+                                                     │
+                                          channel.send('y-update', {u: base64(...)})
+                                                     │
+                                                     ▼  (Supabase Broadcast — ephemeral)
+                                                     │
+                                              (peer's provider)
+                                                     │
+                                          Y.applyUpdate(doc, ...)
+                                                     │
+                                          observer on Y.Array
+                                                     │
+                                                     ▼
+                              commandService.syncExecuteCommand(op.id, {...op.params, trigger:'remote'},
+                                                                {onlyLocal:true, fromCollab:true})
+```
+
+**Why `Y.Array<MutationOp>` and not `Y.Map<sheetId, Y.Map<cellKey, ...>>`:**
+Univer mutations are already conflict-resolvable at the mutation grain. We use
+Yjs as the **causal log + transport-agnostic CRDT envelope**, not for cell-level
+merging. This avoids reimplementing Univer's OT inside Yjs. Tradeoff: two
+clients editing the *same cell* concurrently apply their mutations in
+Yjs-defined order — last-writer-wins per mutation, which is acceptable for v1
+and matches user mental model for spreadsheets.
+
+For finer-grained semantics later, swap the doc shape to
+`Y.Map<sheetId, Y.Map<cellKey, Y.Map<value|style|formula>>>` and write a richer
+mutation→Y.Map translator. Out of scope.
+
+---
+
+## Persistence reconciliation
+
+- **Join:** load latest `udt_workbook_snapshots` row (existing service helper).
+  Construct a fresh `Y.Doc`. Mount Univer with the snapshot via the existing
+  `apiRef.current.createWorkbook(snapshot)` path.
+- **Catch-up:** broadcast a `y-request-state` message; first peer to respond
+  with `y-state` payload supplies the in-flight CRDT updates. If no peers
+  respond within 1500 ms, assume we're alone.
+- **Snapshot rewrite:** only the **host** writes snapshots. Host election is
+  deterministic: lowest `uid` (lex) among connected Awareness peers. Schedule:
+  the existing 2.5 s debounce after a local mutation, PLUS a forced rewrite
+  every 60 s of activity, PLUS a forced rewrite when the Yjs update count
+  exceeds 500 since last save. Late joiners never have to replay a multi-hour
+  Yjs log.
+- The existing `useWorkbookRealtime` snapshot-insert listener stays but its
+  job changes from "hot-swap" to "log the checkpoint." Hot-swap only triggers
+  if the local Yjs doc is more than ~100 ops behind (disaster-recovery).
+
+---
+
+## Awareness / cursors
+
+Use Yjs's standard `Awareness` protocol (`y-protocols/awareness`). Send awareness
+updates on a SEPARATE broadcast event (`y-awareness`) so we can throttle them
+independently of the y-update channel.
+
+State per peer (~80 bytes JSON, see `types.ts` for the typed shape):
+`{uid, name, color, sheetId, row, col, ts}`.
+
+Throttle outbound at 50 ms (well under Broadcast's 100 msg/s per-channel limit).
+Render via a thin `RemoteCursorsLayer.tsx` mounted as sibling to the Univer
+container; translate `(sheetId, row, col)` → pixels via
+`worksheet.getCellPosition(row, col)`.
+
+---
+
+## Deps to install (when implementation begins)
+
+```
+yjs           ^13.6.27     (~70 KB min+gz)
+y-protocols   ^1.0.6       (~6 KB)
+lib0          ^0.2.99      (~15 KB, peer of yjs — usually auto-installed)
+```
+
+**Do NOT install:** `y-websocket` (we use Broadcast), `y-indexeddb` (snapshot
+table is our persistence), `y-supabase` from npm (existing package is
+unmaintained — write our own ~120 LoC provider).
+
+The collab modules are dynamically imported via the existing
+`dynamic(() => import('./WorkbookEditor'), { ssr: false })` wrapper, so non-
+workbook routes pay zero bundle cost.
+
+---
+
+## Implementation checklist (3-5 day estimate)
+
+- [ ] Install yjs + y-protocols (pnpm).
+- [ ] `SupabaseYjsProvider.ts` (~150 LoC): open channel `yjs:workbook:<id>`;
+      send y-update on local `doc.on('updateV2', ...)`; apply on receive;
+      handle 256 KB payload limit via chunked `(seq, total)` frames.
+- [ ] `WorkbookCollabSession.ts` (~200 LoC): subscribe to
+      `commandService.onMutationExecutedForCollab`; emit to Yjs; observe Yjs;
+      apply via `commandService.syncExecuteCommand(... {onlyLocal:true, fromCollab:true})`;
+      short-circuit the outbound listener when `params.trigger === 'remote-collab'`.
+- [ ] Awareness wiring + outbound throttle (50 ms).
+- [ ] `RemoteCursorsLayer.tsx` (~120 LoC): absolute-positioned colored ring
+      per peer; translates `(sheetId, row, col)` via Univer's facade.
+- [ ] Update `WorkbookEditor.tsx`: replace the 2.5 s debounced save with the
+      collab session; host-election gated save path; awareness state setup.
+- [ ] Repurpose `useWorkbookRealtime`: log-only, lazy hot-swap on
+      doc-lag > 100 ops.
+- [ ] **PROBE FIRST**: ~30 min probe that boots Univer and verifies every
+      mutation's `params` survives `JSON.stringify → JSON.parse` cleanly.
+      `params` is typed as serializable but JS objects can carry `Date`,
+      `Map`, etc. through "serializable" promises. If anything fails, fall
+      back to `structuredClone` (perf cost acceptable for sheet edits) or a
+      Univer fork that enforces serializability at mutation registration.
+
+---
+
+## Fallback ladder
+
+- **Ladder rung 1 — Presence-only v1.5.** If the probe fails or the schedule
+  slips, ship just the awareness/cursors layer (~1 day work) plus snapshot-
+  per-save. Users see each other's selections and stop overwriting — real
+  value without the full CRDT cost.
+- **Ladder rung 2 — Faster polling.** Drop the snapshot debounce to 500 ms +
+  reload-on-remote-insert. Cheap but produces visible cell flicker; only
+  worth it after rung 1 lands.
+
+---
+
+## Files in this directory (current vs planned)
+
+| File | Status | Purpose |
+|---|---|---|
+| `types.ts` | ✅ (scaffolded) | Wire-protocol shapes for Yjs + Awareness over Broadcast |
+| `FEATURE.md` | ✅ | This document |
+| `SupabaseYjsProvider.ts` | ⏳ | y-supabase provider (~150 LoC) |
+| `WorkbookCollabSession.ts` | ⏳ | Univer ↔ Yjs adapter (~200 LoC) |
+| `../components/RemoteCursorsLayer.tsx` | ⏳ | Cursor overlay (~120 LoC) |
+
+---
+
+## Change log
+
+- `2026-06-06` — claude: scaffold `types.ts` + this FEATURE.md from the
+  research pass. Captures the full plan and the "do NOT use the Pro preset"
+  decision so the next implementer can start without re-deriving.

--- a/features/data-tables/collab/types.ts
+++ b/features/data-tables/collab/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Collab types — wire-protocol shapes for the workbook CRDT layer (v2).
+ *
+ * See `FEATURE.md` in this directory for the full integration plan.
+ *
+ * V1 of the workbook surface uses snapshot-per-save persistence and is
+ * intentionally NOT collaborative beyond hot-swap on remote snapshot.
+ * V2 layers Yjs CRDT updates over Supabase Broadcast on top of that store —
+ * the snapshot table stays the canonical state, Broadcast handles the
+ * ephemeral causal log between active editors.
+ *
+ * Nothing in this file imports `yjs` so that consumers (e.g. snapshot
+ * tooling) can pull the types without dragging the CRDT lib into the bundle.
+ * The `Y.Doc` / `Awareness` references in JSDoc point at the types provided
+ * by `yjs` and `y-protocols/awareness` once those deps land.
+ */
+
+/** Per-peer presence payload. ~80 bytes JSON. */
+export type AwarenessState = {
+  /** Stable user id (matches auth.uid). */
+  uid: string;
+  /** Display name as shown next to the cursor. */
+  name: string;
+  /** Cursor color (hex, e.g. "#3b82f6"). Derived deterministically from uid. */
+  color: string;
+  /** Univer sheet the cursor is currently focused on. */
+  sheetId: string | null;
+  /** Cursor row index, 0-based. */
+  row: number | null;
+  /** Cursor column index, 0-based. */
+  col: number | null;
+  /** Last-update ms timestamp. Used to age out stale cursors. */
+  ts: number;
+};
+
+/**
+ * Wire envelope for the binary Yjs update over Supabase Broadcast.
+ * Broadcast payloads are JSON, so the binary update is base64-encoded.
+ */
+export type YjsUpdateMessage = {
+  type: "y-update";
+  /** base64(Uint8Array) of the Yjs update. */
+  u: string;
+  /** When chunked, the index of this frame (0-based). */
+  seq?: number;
+  /** When chunked, total number of frames. */
+  total?: number;
+};
+
+/**
+ * Wire envelope for awareness (presence + cursor) updates. Sent on a separate
+ * broadcast event so we can throttle independently of the y-update channel.
+ */
+export type AwarenessMessage = {
+  type: "y-awareness";
+  /** base64(Uint8Array) of the encoded awareness update. */
+  a: string;
+};
+
+/**
+ * Initial-state request broadcast when a new peer joins. The first existing
+ * peer to respond wins; late responses are dropped by client id seen-set.
+ */
+export type StateRequestMessage = {
+  type: "y-request-state";
+  /** Random per-connection id so responders can dedupe. */
+  clientId: string;
+};
+
+/** Response to a StateRequestMessage: the requester's first full doc state. */
+export type StateResponseMessage = {
+  type: "y-state";
+  /** base64(Uint8Array) of `Y.encodeStateAsUpdateV2(doc)`. */
+  sv: string;
+  /** Echoes the requester id so they accept the right response. */
+  forClientId: string;
+};
+
+/** Operational metadata stored next to each shared Y.Doc in memory. */
+export type WorkbookCollabContext = {
+  workbookId: string;
+  /** Stable per-tab session id; used in state-request dedupe. */
+  clientId: string;
+  /** Authenticated user id (matches auth.uid). */
+  uid: string;
+};
+
+/**
+ * Result of the "am I the snapshot host?" deterministic election. The lowest
+ * `uid` (lexicographically) among connected peers writes the canonical
+ * snapshot; other peers skip the autosave path. Re-evaluated whenever
+ * Awareness changes.
+ */
+export type HostElectionResult = {
+  isHost: boolean;
+  hostUid: string | null;
+};

--- a/features/data-tables/components/ImportRouteDialog.tsx
+++ b/features/data-tables/components/ImportRouteDialog.tsx
@@ -1,0 +1,167 @@
+/**
+ * ImportRouteDialog — choose between typed dataset and workbook for an
+ * imported file. Pre-selects the detector's recommendation (badged
+ * "Recommended"); user can override.
+ *
+ * Caller responsibilities:
+ *   - Pass the detection result from `detectImportRoute(file)`.
+ *   - Pass the original `File` for the destination handler.
+ *   - Wire `onCommit({ routing, file })` to perform the actual import.
+ *   - Manage `isOpen` / `onClose`.
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { FileSpreadsheet, FileText, Loader2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import type { ImportRouteDetection, ImportRouting } from "../smart-importer";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  detection: ImportRouteDetection | null;
+  fileName: string;
+  /** Called when the user confirms. Caller dispatches the chosen import. */
+  onCommit: (routing: ImportRouting) => void | Promise<void>;
+  /** True while the parent is running the actual import after commit. */
+  isCommitting?: boolean;
+};
+
+export function ImportRouteDialog({
+  isOpen,
+  onClose,
+  detection,
+  fileName,
+  onCommit,
+  isCommitting = false,
+}: Props) {
+  const [choice, setChoice] = useState<ImportRouting>("typed");
+
+  useEffect(() => {
+    if (detection) setChoice(detection.routing);
+  }, [detection]);
+
+  if (!detection) return null;
+
+  const recommended = detection.routing;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isCommitting) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>How should we import this file?</DialogTitle>
+          <DialogDescription className="truncate" title={fileName}>
+            {fileName}
+            {detection.sheetCount > 1 && (
+              <> · {detection.sheetCount} sheets</>
+            )}
+            {detection.firstSheetRowCount > 0 && (
+              <> · {detection.firstSheetRowCount} rows on first sheet</>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 py-2">
+          <RouteOption
+            kind="typed"
+            selected={choice === "typed"}
+            recommended={recommended === "typed"}
+            onSelect={() => setChoice("typed")}
+            reasons={detection.reasons.typed}
+            description="One row per record, each column has a declared type. Queryable, indexable, agent-friendly. Best for clean tabular data."
+          />
+          <RouteOption
+            kind="workbook"
+            selected={choice === "workbook"}
+            recommended={recommended === "workbook"}
+            onSelect={() => setChoice("workbook")}
+            reasons={detection.reasons.workbook}
+            description="Lossless spreadsheet — multi-sheet, formulas, merged cells, formatting preserved. Best when the original layout matters."
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isCommitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void onCommit(choice)} disabled={isCommitting}>
+            {isCommitting ? (
+              <Loader2 className="size-4 mr-2 animate-spin" />
+            ) : null}
+            Import as{" "}
+            {choice === "typed" ? "Typed Dataset" : "Workbook"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RouteOption({
+  kind,
+  selected,
+  recommended,
+  onSelect,
+  reasons,
+  description,
+}: {
+  kind: ImportRouting;
+  selected: boolean;
+  recommended: boolean;
+  onSelect: () => void;
+  reasons: string[];
+  description: string;
+}) {
+  const Icon = kind === "workbook" ? FileSpreadsheet : FileText;
+  const title = kind === "workbook" ? "Workbook" : "Typed Dataset";
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex items-start gap-3 rounded-md border p-3 text-left transition-colors ${
+        selected
+          ? "border-primary bg-primary/5"
+          : "border-border bg-card hover:bg-muted"
+      }`}
+    >
+      <Icon
+        className={`mt-0.5 size-5 flex-shrink-0 ${
+          selected ? "text-primary" : "text-muted-foreground"
+        }`}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{title}</span>
+          {recommended && (
+            <Badge variant="secondary" className="text-xs">
+              Recommended
+            </Badge>
+          )}
+        </div>
+        <div className="mt-1 text-xs text-muted-foreground">{description}</div>
+        {reasons.length > 0 && (
+          <div className="mt-1.5 text-xs text-muted-foreground">
+            <span className="font-medium">Detected:</span>{" "}
+            {reasons.join("; ")}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/features/data-tables/smart-import-pickup.ts
+++ b/features/data-tables/smart-import-pickup.ts
@@ -1,0 +1,36 @@
+/**
+ * smart-import-pickup — module-level handoff slot for the cross-route
+ * Smart Import flow.
+ *
+ * `File` objects are not serializable through localStorage, sessionStorage,
+ * URL params, or Redux. The Smart Import flow on `/workbooks` may need to
+ * route the user to `/data` with a pre-loaded file (when the detector says
+ * "typed dataset"). The /data page reads this slot once and clears it.
+ *
+ * Module-level state is fine here because:
+ *   - It lives on the client (no SSR concerns — no read from a server file).
+ *   - It is single-shot: the consumer reads + clears immediately.
+ *   - It is scoped to a single browser tab's runtime, which is exactly the
+ *     handoff lifetime we need.
+ *
+ * If the user closes the tab between handoff and pickup, the slot is gone
+ * along with the page — the right behavior (a new tab won't get a stale file).
+ */
+
+type Slot = {
+  file: File | null;
+  takenAt: number;
+};
+
+export const smartImportPickupSlot: Slot = {
+  file: null,
+  takenAt: 0,
+};
+
+/** Consume the pickup slot. Returns the file once, then clears the slot. */
+export function consumeSmartImportFile(): File | null {
+  const f = smartImportPickupSlot.file;
+  smartImportPickupSlot.file = null;
+  smartImportPickupSlot.takenAt = 0;
+  return f;
+}

--- a/features/data-tables/smart-importer.ts
+++ b/features/data-tables/smart-importer.ts
@@ -1,0 +1,287 @@
+/**
+ * smart-importer — heuristic detection that routes an XLSX/CSV upload to
+ * the better destination: typed dataset (/data) vs lossless workbook (/workbooks).
+ *
+ * Why the binary choice matters:
+ *   - **Typed dataset** = one row per object, each cell a JSONB value keyed
+ *     by a first-class field. Best for "rational" tabular data — header row
+ *     + uniform-type columns + no formatting nuance. Queryable, indexable,
+ *     edit-per-cell.
+ *   - **Workbook** = Univer-rendered spreadsheet with merged cells, formulas,
+ *     formatting, multi-sheet, multi-region. Best for "look-sensitive" sheets.
+ *
+ * The detector runs in the browser before either import path begins. It does
+ * NOT navigate or commit anything — it returns a routing recommendation plus
+ * confidence and reasons. The caller decides what to do with it (auto-route,
+ * show a confirm dialog, etc.).
+ *
+ * Algorithm: scores 7 signals on each side and returns the winner. Designed
+ * to surface "obvious workbook" cases (merged cells, formulas, multi-sheet,
+ * heavy styling) with high confidence and "obvious typed" cases (uniform
+ * columns, clear header) with high confidence, while flagging genuinely
+ * ambiguous files for user choice.
+ */
+
+import * as XLSX from "xlsx";
+
+export type ImportRouting = "typed" | "workbook";
+
+export type ImportRouteDetection = {
+  routing: ImportRouting;
+  /** 0..1. Above 0.6 we recommend auto-routing; below, surface a choice. */
+  confidence: number;
+  scores: { typed: number; workbook: number };
+  /** Short user-facing reasons, one per side. */
+  reasons: { typed: string[]; workbook: string[] };
+  /** Number of sheets the file contains. */
+  sheetCount: number;
+  /** Row count of the first sheet (the typed-import candidate). */
+  firstSheetRowCount: number;
+};
+
+const SCORES = {
+  MERGED_CELLS: 80,
+  FORMULA_HEAVY: 60,
+  MULTIPLE_SHEETS: 40,
+  UNIFORM_COLUMNS: 50,
+  MIXED_COLUMNS: 50,
+  HEADER_ROW: 40,
+  SPARSITY: 30,
+  STYLED_CELLS: 30,
+  WIDE_DATA_EXPORT: 20,
+  TALL_LOG_LIKE: 20,
+};
+
+const FORMULA_PROPORTION_THRESHOLD = 0.05;
+const UNIFORM_COLUMN_PCT_HIGH = 0.8;
+const UNIFORM_COLUMN_PCT_LOW = 0.4;
+const PER_COLUMN_UNIFORMITY_THRESHOLD = 0.9;
+const SPARSITY_THRESHOLD = 0.15;
+const STYLED_CELLS_THRESHOLD = 0.1;
+const SAMPLE_ROWS_FOR_UNIFORMITY = 100;
+
+/**
+ * Read an XLSX/CSV file and decide where it should land. Pure detection —
+ * does NOT mutate state, navigate, or hit the server.
+ */
+export async function detectImportRoute(
+  file: File,
+): Promise<ImportRouteDetection> {
+  const buffer = await file.arrayBuffer();
+  const wb = XLSX.read(buffer, {
+    type: "array",
+    cellDates: true,
+    cellFormula: true,
+    cellStyles: true,
+  });
+
+  let workbookScore = 0;
+  let typedScore = 0;
+  const workbookReasons: string[] = [];
+  const typedReasons: string[] = [];
+
+  const sheetNames = wb.SheetNames;
+  const firstSheetName = sheetNames[0];
+  const firstSheet = firstSheetName ? wb.Sheets[firstSheetName] : undefined;
+
+  // Multi-sheet ----------------------------------------------------------
+  if (sheetNames.length > 1) {
+    workbookScore += SCORES.MULTIPLE_SHEETS;
+    workbookReasons.push(`${sheetNames.length} sheets`);
+  }
+
+  // Empty / unreadable ---------------------------------------------------
+  if (!firstSheet) {
+    return {
+      routing: "typed",
+      confidence: 0,
+      scores: { typed: 0, workbook: 0 },
+      reasons: { typed: ["empty file"], workbook: [] },
+      sheetCount: 0,
+      firstSheetRowCount: 0,
+    };
+  }
+
+  // Per-sheet pass: count formulas, styled cells, merges --------------
+  let formulaCellCount = 0;
+  let styledCellCount = 0;
+  let totalNonEmptyCells = 0;
+  let totalMerges = 0;
+
+  for (const name of sheetNames) {
+    const ws = wb.Sheets[name];
+    if (!ws) continue;
+    const mergesArr = ws["!merges"] as XLSX.Range[] | undefined;
+    if (mergesArr && mergesArr.length > 0) totalMerges += mergesArr.length;
+    for (const key in ws) {
+      if (key.startsWith("!")) continue;
+      totalNonEmptyCells++;
+      const cell = ws[key] as XLSX.CellObject | undefined;
+      if (!cell) continue;
+      if (typeof cell.f === "string" && cell.f.length > 0) formulaCellCount++;
+      if (cell.s) styledCellCount++;
+    }
+  }
+
+  // Merged cells --------------------------------------------------------
+  if (totalMerges > 0) {
+    workbookScore += SCORES.MERGED_CELLS;
+    workbookReasons.push(
+      `${totalMerges} merged cell range${totalMerges === 1 ? "" : "s"}`,
+    );
+  }
+
+  // Formula-heavy -------------------------------------------------------
+  const formulaProportion =
+    totalNonEmptyCells > 0 ? formulaCellCount / totalNonEmptyCells : 0;
+  if (formulaProportion > FORMULA_PROPORTION_THRESHOLD) {
+    workbookScore += SCORES.FORMULA_HEAVY;
+    workbookReasons.push(
+      `${formulaCellCount} formula cell${formulaCellCount === 1 ? "" : "s"}`,
+    );
+  }
+
+  // Style density -------------------------------------------------------
+  const styleProportion =
+    totalNonEmptyCells > 0 ? styledCellCount / totalNonEmptyCells : 0;
+  if (styleProportion > STYLED_CELLS_THRESHOLD) {
+    workbookScore += SCORES.STYLED_CELLS;
+    workbookReasons.push("custom cell formatting");
+  }
+
+  // First-sheet structural analysis ------------------------------------
+  // We only typed-evaluate the FIRST sheet because typed datasets are
+  // single-table — extra sheets are workbook-territory regardless.
+  const jsonData = XLSX.utils.sheet_to_json(firstSheet, {
+    defval: null,
+  }) as Array<Record<string, unknown>>;
+  const refRange = XLSX.utils.decode_range(firstSheet["!ref"] ?? "A1:A1");
+  const sheetCols = refRange.e.c - refRange.s.c + 1;
+  const sheetRows = refRange.e.r - refRange.s.r + 1;
+
+  if (jsonData.length > 0) {
+    const headers = Object.keys(jsonData[0]);
+
+    // Per-column uniformity --------------------------------------------
+    let uniformColumns = 0;
+    let samplesSeen = 0;
+    for (const h of headers) {
+      const values = jsonData
+        .slice(0, SAMPLE_ROWS_FOR_UNIFORMITY)
+        .map((row) => row[h])
+        .filter((v) => v !== null && v !== undefined && v !== "");
+      if (values.length === 0) {
+        // An empty column is "uniform" trivially — don't double-count it
+        // against typed-detection, but don't credit it either.
+        continue;
+      }
+      samplesSeen++;
+      const typeCounts: Record<string, number> = {};
+      for (const v of values) {
+        const t = simpleTypeOf(v);
+        typeCounts[t] = (typeCounts[t] || 0) + 1;
+      }
+      const dominant = Math.max(...Object.values(typeCounts));
+      if (dominant / values.length >= PER_COLUMN_UNIFORMITY_THRESHOLD) {
+        uniformColumns++;
+      }
+    }
+    const uniformFraction = samplesSeen > 0 ? uniformColumns / samplesSeen : 0;
+    if (uniformFraction > UNIFORM_COLUMN_PCT_HIGH) {
+      typedScore += SCORES.UNIFORM_COLUMNS;
+      typedReasons.push(
+        `${uniformColumns} of ${samplesSeen} columns have uniform types`,
+      );
+    } else if (uniformFraction < UNIFORM_COLUMN_PCT_LOW && samplesSeen > 0) {
+      workbookScore += SCORES.MIXED_COLUMNS;
+      workbookReasons.push("heterogeneous column types");
+    }
+
+    // Header row probability -------------------------------------------
+    const row0Values = headers
+      .map((h) => jsonData[0]?.[h])
+      .filter((v) => v !== null && v !== undefined);
+    const row0AllStrings =
+      row0Values.length > 0 &&
+      row0Values.every((v) => typeof v === "string");
+    const row1 = jsonData[1];
+    if (row0AllStrings && row1) {
+      const row1HasNonString = Object.values(row1).some(
+        (v) =>
+          v !== null &&
+          v !== undefined &&
+          v !== "" &&
+          typeof v !== "string",
+      );
+      if (row1HasNonString) {
+        typedScore += SCORES.HEADER_ROW;
+        typedReasons.push("header row followed by typed data");
+      }
+    }
+
+    // Wide-data export pattern -----------------------------------------
+    if (
+      sheetCols > 100 &&
+      sheetRows > 500 &&
+      formulaProportion < 0.02 &&
+      uniformFraction > UNIFORM_COLUMN_PCT_HIGH
+    ) {
+      typedScore += SCORES.WIDE_DATA_EXPORT;
+      typedReasons.push("large structured data export");
+    }
+
+    // Tall append-only / log pattern ------------------------------------
+    if (
+      sheetRows > 5000 &&
+      sheetCols < 20 &&
+      uniformFraction > UNIFORM_COLUMN_PCT_HIGH
+    ) {
+      typedScore += SCORES.TALL_LOG_LIKE;
+      typedReasons.push("large append-only / log-style dataset");
+    }
+
+    // Sparsity ----------------------------------------------------------
+    const usableCells = jsonData.length * headers.length;
+    const cellDensity = usableCells / Math.max(sheetRows * sheetCols, 1);
+    if (cellDensity < SPARSITY_THRESHOLD) {
+      workbookScore += SCORES.SPARSITY;
+      workbookReasons.push("sparse multi-region layout");
+    }
+  }
+
+  // Decision ------------------------------------------------------------
+  const total = Math.max(typedScore + workbookScore, 1);
+  const winnerScore = Math.max(typedScore, workbookScore);
+  const loserScore = Math.min(typedScore, workbookScore);
+  // Confidence: dominance of the winner, normalized so a runaway score is 1.
+  const confidence =
+    winnerScore === 0
+      ? 0
+      : (winnerScore - loserScore) / Math.max(winnerScore, 1);
+
+  return {
+    routing: workbookScore > typedScore ? "workbook" : "typed",
+    confidence: Math.max(0, Math.min(1, confidence)),
+    scores: { typed: typedScore, workbook: workbookScore },
+    reasons: {
+      typed: typedReasons.length > 0 ? typedReasons : ["no strong signal"],
+      workbook:
+        workbookReasons.length > 0 ? workbookReasons : ["no strong signal"],
+    },
+    sheetCount: sheetNames.length,
+    firstSheetRowCount: jsonData.length,
+  };
+}
+
+function simpleTypeOf(v: unknown): "number" | "string" | "boolean" | "date" {
+  if (v instanceof Date) return "date";
+  if (typeof v === "number") return "number";
+  if (typeof v === "boolean") return "boolean";
+  return "string";
+}
+
+/**
+ * Threshold above which we recommend auto-routing (skip the confirm dialog).
+ * Anything below this should surface the choice to the user.
+ */
+export const AUTO_ROUTE_CONFIDENCE = 0.6;

--- a/features/data-tables/workbook-service.ts
+++ b/features/data-tables/workbook-service.ts
@@ -38,6 +38,12 @@ export type CreateWorkbookArgs = {
   projectId?: string | null;
   taskId?: string | null;
   isPublic?: boolean;
+  /**
+   * cld_files.id of the source upload (XLSX / CSV blob). Set on the import
+   * flow so the lossless original is recoverable; FK is ON DELETE SET NULL,
+   * so deleting the file just nulls the link — the workbook survives.
+   */
+  originalFileId?: string | null;
 };
 
 export async function createWorkbook(
@@ -61,6 +67,7 @@ export async function createWorkbook(
       project_id: args.projectId ?? null,
       task_id: args.taskId ?? null,
       is_public: args.isPublic ?? false,
+      original_file_id: args.originalFileId ?? null,
       user_id: userData.user.id,
     })
     .select("*")

--- a/migrations/udt_v2_retention_and_original_file_fk.sql
+++ b/migrations/udt_v2_retention_and_original_file_fk.sql
@@ -1,0 +1,115 @@
+-- ============================================================================
+-- udt_v2_retention_and_original_file_fk
+-- ============================================================================
+--
+-- Two unrelated-but-small additions, kept together so we don't churn the
+-- migration history with single-statement files:
+--
+--   1. Weekly pg_cron job that trims udt_dataset_row_versions per the policy:
+--      "keep ALL versions ≤ 2 weeks old, AND ALWAYS keep the most recent 2
+--      versions per row regardless of age." (Wave H, decided 2026-06-05.)
+--      A version row is deleted only when BOTH conditions are true:
+--        - older than 14 days, AND
+--        - not in the top-2-by-recency for its row_id.
+--
+--   2. FK on udt_workbooks.original_file_id → cld_files(id). The column has
+--      existed since udt_v2_backbone but the FK was deliberately deferred
+--      until the workbook surface landed (it's here now). ON DELETE SET NULL
+--      so deleting the source file does NOT cascade-delete the workbook —
+--      losing the link to the original is acceptable; losing the workbook is
+--      not.
+-- ============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Retention trimmer for udt_dataset_row_versions
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.udt_dataset_row_versions_trim()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted bigint;
+  v_started timestamptz := clock_timestamp();
+BEGIN
+  WITH ranked AS (
+    SELECT
+      id,
+      row_id,
+      changed_at,
+      ROW_NUMBER() OVER (PARTITION BY row_id ORDER BY changed_at DESC) AS recency_rank,
+      (changed_at < (now() - INTERVAL '14 days')) AS is_older_than_two_weeks
+    FROM udt_dataset_row_versions
+  ),
+  to_delete AS (
+    SELECT id
+    FROM ranked
+    WHERE recency_rank > 2
+      AND is_older_than_two_weeks
+  ),
+  deleted AS (
+    DELETE FROM udt_dataset_row_versions
+    WHERE id IN (SELECT id FROM to_delete)
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO v_deleted FROM deleted;
+
+  RETURN jsonb_build_object(
+    'function',     'udt_dataset_row_versions_trim',
+    'policy',       'keep latest 2 OR within 14d',
+    'rows_deleted', v_deleted,
+    'duration_ms',  EXTRACT(MILLISECOND FROM (clock_timestamp() - v_started))::int,
+    'trimmed_at',   now()
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.udt_dataset_row_versions_trim() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.udt_dataset_row_versions_trim() TO service_role;
+
+-- Cron schedule: Sunday 03:00 UTC. Idempotent — re-running the migration
+-- will unschedule the old one before re-adding so the schedule never drifts
+-- to two copies.
+DO $$
+BEGIN
+  PERFORM cron.unschedule('udt_dataset_row_versions_trim_weekly');
+EXCEPTION WHEN OTHERS THEN
+  -- No existing job — fine.
+  NULL;
+END$$;
+
+SELECT cron.schedule(
+  'udt_dataset_row_versions_trim_weekly',
+  '0 3 * * 0',   -- minute hour day-of-month month day-of-week
+  $cron$ SELECT public.udt_dataset_row_versions_trim(); $cron$
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. FK: udt_workbooks.original_file_id -> cld_files(id)
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'udt_workbooks_original_file_id_fkey'
+      AND conrelid = 'public.udt_workbooks'::regclass
+  ) THEN
+    ALTER TABLE public.udt_workbooks
+      ADD CONSTRAINT udt_workbooks_original_file_id_fkey
+      FOREIGN KEY (original_file_id)
+      REFERENCES public.cld_files(id)
+      ON DELETE SET NULL;
+  END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS idx_udt_workbooks_original_file_id
+  ON public.udt_workbooks(original_file_id)
+  WHERE original_file_id IS NOT NULL;
+
+COMMIT;

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -19818,7 +19818,15 @@ export type Database = {
           user_id?: string
           workbook_name?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "udt_workbooks_original_file_id_fkey"
+            columns: ["original_file_id"]
+            isOneToOne: false
+            referencedRelation: "cld_files"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       ui_client: {
         Row: {
@@ -28085,6 +28093,7 @@ export type Database = {
         }
         Returns: Json
       }
+      udt_dataset_row_versions_trim: { Args: never; Returns: Json }
       udt_upsert_cell: {
         Args: {
           p_field_name: string


### PR DESCRIPTION
## What this ships

Final closeout pass on the spreadsheet UX. **All user decisions from 2026-06-06 implemented.**

### 1. Wave H — version-history retention (live)
Migration `udt_v2_retention_and_original_file_fk` (applied + verified live):
- `udt_dataset_row_versions_trim()` — `SECURITY DEFINER`, granted `service_role` only. Per-row policy: delete versions where `recency_rank > 2` AND older than 14 days. Returns `{rows_deleted, duration_ms, trimmed_at}`.
- pg_cron job `udt_dataset_row_versions_trim_weekly` scheduled `0 3 * * 0` (Sundays 03:00 UTC). Unscheduled-then-re-scheduled idempotently so re-running cannot drift.

### 2. aidream attribution — honest NULL (no code change)
Per your direction. Service-role / pool writes correctly record `changed_by = NULL` — the audit log honestly says "system write" rather than misattributing to row owners.

### 3. `udt_workbooks.original_file_id` FK live + wired
- FK: `REFERENCES cld_files(id) ON DELETE SET NULL` + partial index. (Column existed since `udt_v2_backbone`; FK was deferred until the workbook surface landed.)
- Workbook import flow now uploads the source XLSX/CSV via `fileHandler.upload({kind:'file'}, {folderPath:'Workbooks/Imports'})` before `createWorkbook`. The returned `cld_files.id` is stored on the workbook row. Upload failure is non-fatal — workbook still imports (link is a recoverability nicety; FK is set-null on delete).

### 4. Smart importer (P3) — shipped
- **`features/data-tables/smart-importer.ts`** — 7-signal heuristic that picks between typed dataset and workbook: merged cells (+80), formula density >5% (+60), multi-sheet (+40), per-column type uniformity ≥80% (+50 typed) or ≤40% (+50 workbook), header-row pattern (+40 typed), sparsity <15% (+30 workbook), custom styling >10% (+30 workbook). Plus secondary wide-data and tall-log signals.
- **`ImportRouteDialog.tsx`** — pre-selects the recommendation with a `Recommended` badge; shows the reasons each side scored; user can override.
- **`smart-import-pickup.ts`** — module-level slot that carries the `File` across the route boundary (sessionStorage cannot hold a `File`). Single-shot consume.
- **`/workbooks` page** — new `Sparkles` "Smart import" button. Workbook routing reuses the existing workbook import path; typed routing stashes the file + navigates to `/data?smartImport=1`.
- **`/data` page** — reads the query, consumes the slot, opens `ImportTableModal` pre-loaded.
- **`ImportTableModal`** — new `prefilledFile?: File | null` prop + useEffect that auto-runs `handleFileSelect`.

### 5. Bulk paste from Excel/Sheets clipboard
- **`PasteRowsDialog.tsx`** (new) — 2-stage dialog:
  - Stage 1: paste TSV/CSV; Papa-parse auto-detects delimiter.
  - Stage 2: column-mapping preview, matched by `sanitizeFieldName`. Unmatched paste columns flagged "(skipped — no matching column)"; unmatched dataset columns flagged "(unmatched dataset column — will be empty)".
  - Confirm → builds `BulkInsertOp[]` and runs `bulkWrite({tableId, operations})` in one atomic transaction.
- **`TableToolbar`** — `Clipboard`-icon "Paste rows" button next to "Add Row"; hidden when `isReadOnly`. Renders `<PasteRowsDialog>` next to `<AddRowModal>`.
- **`UserTableViewer`** — adds `showPasteRowsDialog` state + threads through.

### 6. CRDT v2 collab — scaffolded (per "do it last" direction)
Implementation is multi-day and deferred. Foundation laid so the next session can start immediately:
- **`features/data-tables/collab/types.ts`** — all wire-protocol shapes typed (`AwarenessState`, `YjsUpdateMessage`, `AwarenessMessage`, `StateRequest/Response`, `WorkbookCollabContext`, `HostElectionResult`). No `yjs` import yet — types only.
- **`features/data-tables/collab/FEATURE.md`** — the full integration plan from the research pass:
  - **Verdict:** do NOT use `@univerjs/preset-sheets-collaboration` (requires proprietary Univer Pro "universer" backend with custom OT wire format). Build our own bridge via the **public** `commandService.onMutationExecutedForCollab` hook.
  - **Bridge:** `Y.Array<MutationOp>` as the causal log; `Y.encodeStateAsUpdateV2` over Supabase Broadcast (chunked at 256 KB).
  - **Awareness/cursors** on a separate broadcast event, throttled 50 ms.
  - **Host election** for snapshot writes via lexicographic lowest `uid` — deterministic, no election protocol needed.
  - **Snapshot reconciliation** — load latest, then catch up from peers via `y-request-state`; 1500 ms timeout assumes solo if no peer responds.
  - **Implementation checklist** + 3-5 day estimate + **fallback ladder** (presence-only v1.5 / faster polling) documented so next implementer never has to re-derive.

## Live DB migrations applied

1. `udt_v2_retention_and_original_file_fk` — retention trim + pg_cron + FK.

## Active pending list (`features/data-tables/FEATURE.md` is canonical)

🛑 **None — all decision blockers resolved.**

⏳ **One multi-day task remaining:**
- Workbook CRDT v2 implementation. Foundation scaffolded; ~3-5 days estimated. Green-lit, scoped for next session.

## Test plan after merge

- [ ] `/data/[id]` → open Edit menu → "Paste rows" button visible (not for shared viewers).
- [ ] Paste 5 rows of TSV from Google Sheets → see column-mapping preview → confirm → toast "Pasted 5 rows".
- [ ] `/workbooks` → "Smart import" button visible.
- [ ] Upload a clean tabular .xlsx → "Recommended: Typed Dataset" with detection reasons → confirm → lands in `/data` with the file pre-loaded in Import preview.
- [ ] Upload a multi-sheet .xlsx with merged cells / formulas → "Recommended: Workbook" → confirm → workbook opens with original stored in `cld_files`.
- [ ] In Supabase SQL editor: `SELECT * FROM cron.job WHERE jobname LIKE 'udt_%';` — confirm the trim schedule is `0 3 * * 0`.
- [ ] `SELECT public.udt_dataset_row_versions_trim();` — should return `{rows_deleted, duration_ms, trimmed_at}` (0 deleted today since no rows are >14 days old yet).
- [ ] `SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'udt_workbooks_original_file_id_fkey';` — confirm FK exists.

https://claude.ai/code/session_01EDdu4Q3WpMks2SEeYBEq6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDdu4Q3WpMks2SEeYBEq6j)_