### PR TITLE
fix: user feedback triage — CMS summary types + one SEO pixel rule

### DIFF
--- a/app/api/cms/sites/route.ts
+++ b/app/api/cms/sites/route.ts
@@ -318,10 +318,13 @@ export async function POST(request: NextRequest) {
       case "admin_list_sites": {
         await requireSuperAdmin();
 
+        // Same SUMMARY contract as `list` above — `ClientSiteSummary`, never a
+        // full row. `data_api_key` is read only to compute the boolean and is
+        // stripped before it leaves the route.
         const { data, error } = await db
           .from("client_sites")
           .select(
-            "id, slug, name, domain, is_active, owner_user_id, settings, created_at, updated_at",
+            "id, slug, name, domain, is_active, owner_user_id, favicon, settings, created_at, updated_at, data_api_key",
           )
           .order("name");
 
@@ -330,7 +333,11 @@ export async function POST(request: NextRequest) {
           return NextResponse.json({ error: error.message }, { status: 500 });
         }
 
-        return NextResponse.json({ sites: data ?? [] });
+        const sites = (data ?? []).map(({ data_api_key, ...site }) => ({
+          ...site,
+          has_data_api_key: Boolean(data_api_key),
+        }));
+        return NextResponse.json({ sites });
       }
 
       case "admin_update_policy": {

--- a/features/cms/components/admin/ActivityFeedPanel.tsx
+++ b/features/cms/components/admin/ActivityFeedPanel.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo } from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { useCmsAdminActivity } from '../../hooks/useCmsAdminActivity';
-import type { ClientSite } from '../../types';
+import type { ClientSiteSummary } from '../../types';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -62,7 +62,7 @@ function ActorBadge({ actor }: { actor: string | undefined }) {
     );
 }
 
-export default function ActivityFeedPanel({ sites }: { sites: ClientSite[] }) {
+export default function ActivityFeedPanel({ sites }: { sites: ClientSiteSummary[] }) {
     const [siteId, setSiteId] = useState<string>('all');
     const [entityType, setEntityType] = useState<string>('all');
     const [actor, setActor] = useState<string>('all');

--- a/features/cms/components/admin/AssetsPanel.tsx
+++ b/features/cms/components/admin/AssetsPanel.tsx
@@ -17,7 +17,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from "@/lib/toast";
 import { fileHandler } from "@/features/files/handler/handler";
 import { AssetInUseError, CmsAssetService } from '../../services/cmsService';
-import type { AssetComponentUsage, AssetPageUsage, ClientAsset, ClientSite } from '../../types';
+import type { AssetComponentUsage, AssetPageUsage, ClientAsset, ClientSiteSummary } from '../../types';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -81,7 +81,7 @@ interface DeleteState {
     inUse: boolean;
 }
 
-export default function AssetsPanel({ sites }: { sites: ClientSite[] }) {
+export default function AssetsPanel({ sites }: { sites: ClientSiteSummary[] }) {
     const [siteId, setSiteId] = useState<string>(sites[0]?.id ?? '');
     const [assets, setAssets] = useState<ClientAsset[]>([]);
     const [isLoading, setIsLoading] = useState(false);

--- a/features/cms/components/admin/CmsAgentsAdminClient.tsx
+++ b/features/cms/components/admin/CmsAgentsAdminClient.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { CmsSiteService } from '../../services/cmsService';
-import type { ClientSite } from '../../types';
+import type { ClientSiteSummary } from '../../types';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Loader2, AlertCircle, Radio } from 'lucide-react';
 import ActivityFeedPanel from './ActivityFeedPanel';
@@ -12,7 +12,7 @@ import ApprovalsQueuePanel from './ApprovalsQueuePanel';
 import AssetsPanel from './AssetsPanel';
 
 export default function CmsAgentsAdminClient() {
-    const [sites, setSites] = useState<ClientSite[]>([]);
+    const [sites, setSites] = useState<ClientSiteSummary[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
@@ -32,7 +32,7 @@ export default function CmsAgentsAdminClient() {
         fetchSites();
     }, [fetchSites]);
 
-    const handleSiteUpdated = (updated: ClientSite) => {
+    const handleSiteUpdated = (updated: ClientSiteSummary) => {
         setSites((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
     };
 

--- a/features/cms/components/admin/PolicyEditorPanel.tsx
+++ b/features/cms/components/admin/PolicyEditorPanel.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState } from 'react';
 import { CmsSiteService } from '../../services/cmsService';
-import type { AgentWritePolicy, ClientSite } from '../../types';
+import type { AgentWritePolicy, ClientSiteSummary } from '../../types';
+import { toClientSiteSummary } from '../../types';
 import {
     Select,
     SelectContent,
@@ -22,18 +23,20 @@ const POLICY_META: Record<AgentWritePolicy, { label: string; icon: typeof Shield
 };
 
 interface Props {
-    sites: ClientSite[];
-    onSiteUpdated: (site: ClientSite) => void;
+    sites: ClientSiteSummary[];
+    onSiteUpdated: (site: ClientSiteSummary) => void;
 }
 
 export default function PolicyEditorPanel({ sites, onSiteUpdated }: Props) {
     const [savingId, setSavingId] = useState<string | null>(null);
 
-    const handleChange = async (site: ClientSite, policy: AgentWritePolicy) => {
+    const handleChange = async (site: ClientSiteSummary, policy: AgentWritePolicy) => {
         setSavingId(site.id);
         try {
             const updated = await CmsSiteService.adminUpdatePolicy(site.id, { agentWritePolicy: policy });
-            onSiteUpdated(updated);
+            // The write returns a FULL row; the list holds summaries. Narrow through
+            // the one canonical converter so the two shapes can never diverge.
+            onSiteUpdated(toClientSiteSummary(updated));
             toast.success(`"${site.name}" agent policy set to ${POLICY_META[policy].label}`);
         } catch (err) {
             toast.error(err instanceof Error ? err.message : 'Failed to update policy');

--- a/features/cms/components/admin/SitePageTreePanel.tsx
+++ b/features/cms/components/admin/SitePageTreePanel.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { CmsPageService } from '../../services/cmsService';
 import { clientPageUrl, clientSiteRootUrl, sitePreviewToken } from '../../utils/pageUrls';
-import type { ClientPageSummary, ClientSite } from '../../types';
+import type { ClientPageSummary, ClientSiteSummary } from '../../types';
 import {
     Select,
     SelectContent,
@@ -18,7 +18,7 @@ import { ExternalLink, Eye, Loader2, RefreshCw, FileText } from 'lucide-react';
 
 type AdminPage = ClientPageSummary & { client_id: string };
 
-export default function SitePageTreePanel({ sites }: { sites: ClientSite[] }) {
+export default function SitePageTreePanel({ sites }: { sites: ClientSiteSummary[] }) {
     const [siteId, setSiteId] = useState<string>(sites[0]?.id ?? '');
     const [pages, setPages] = useState<AdminPage[]>([]);
     const [isLoading, setIsLoading] = useState(true);

--- a/features/cms/services/cmsService.ts
+++ b/features/cms/services/cmsService.ts
@@ -139,8 +139,13 @@ export const CmsSiteService = {
 
     // ── Admin (requireSuperAdmin, fleet-wide, bypasses ownership) ─────────
 
-    async adminListSites(): Promise<ClientSite[]> {
-        const res = await callApi<{ sites: ClientSite[] }>('sites', 'admin_list_sites');
+    /**
+     * SUMMARY rows only — same contract as `listSites`, fleet-wide instead of
+     * owner-scoped. Need a full row (`theme_config`, `navigation`, …)?
+     * `getSite(id)`.
+     */
+    async adminListSites(): Promise<ClientSiteSummary[]> {
+        const res = await callApi<{ sites: ClientSiteSummary[] }>('sites', 'admin_list_sites');
         return res.sites;
     },
 

--- a/features/marketing/seo/serp/MetadataAnalyzer.tsx
+++ b/features/marketing/seo/serp/MetadataAnalyzer.tsx
@@ -91,8 +91,9 @@ export function MetadataAnalyzer({
 
   const titleCharOk = titleEval.charCount <= TITLE_LIMITS.maxChars;
   const descCharOk = descEval.charCount <= DESCRIPTION_LIMITS.maxChars;
-  const titleAllOk = titleEval.desktopOk && titleEval.mobileOk && titleCharOk;
-  const descAllOk = descEval.desktopOk && descEval.mobileOk && descCharOk;
+  // One pixel rule, not a desktop/mobile pair — see `TITLE_LIMITS`.
+  const titleAllOk = titleEval.desktopOk && titleCharOk;
+  const descAllOk = descEval.desktopOk && descCharOk;
   const hasData = titleEval.charCount > 0 || descEval.charCount > 0;
 
   async function handleFetchMetadata() {
@@ -242,7 +243,7 @@ export function MetadataAnalyzer({
                       chars: titleEval.charCount,
                       charLimit: TITLE_LIMITS.maxChars,
                       pixels: titleEval.pixelWidth,
-                      pixelLimit: TITLE_LIMITS.desktopPx,
+                      pixelLimit: TITLE_LIMITS.maxPx,
                       ok: titleEval.ok,
                       desktopOk: titleEval.desktopOk,
                       mobileOk: titleEval.mobileOk,
@@ -259,7 +260,7 @@ export function MetadataAnalyzer({
                       chars: descEval.charCount,
                       charLimit: DESCRIPTION_LIMITS.maxChars,
                       pixels: descEval.pixelWidth,
-                      pixelLimit: DESCRIPTION_LIMITS.desktopPx,
+                      pixelLimit: DESCRIPTION_LIMITS.maxPx,
                       ok: descEval.ok,
                       desktopOk: descEval.desktopOk,
                       mobileOk: descEval.mobileOk,
@@ -317,8 +318,8 @@ export function MetadataAnalyzer({
                 Desktop
               </span>
               <span className="ml-auto text-[10px] text-muted-foreground">
-                Max {TITLE_LIMITS.desktopPx}px title ·{" "}
-                {DESCRIPTION_LIMITS.desktopPx}
+                Max {TITLE_LIMITS.maxPx}px title ·{" "}
+                {DESCRIPTION_LIMITS.maxPx}
                 px description
               </span>
             </div>
@@ -342,8 +343,8 @@ export function MetadataAnalyzer({
                 Mobile
               </span>
               <span className="ml-auto text-[10px] text-muted-foreground">
-                Max {TITLE_LIMITS.mobilePx}px title ·{" "}
-                {DESCRIPTION_LIMITS.mobilePx}px description
+                Max {TITLE_LIMITS.maxPx}px title ·{" "}
+                {DESCRIPTION_LIMITS.maxPx}px description
               </span>
             </div>
             <CardContent className="border-0 p-0">

--- a/features/marketing/seo/serp/README.md
+++ b/features/marketing/seo/serp/README.md
@@ -8,18 +8,23 @@ Presentational core — no Redux, no data fetching. Give it text, it renders.
 
 `char-widths.ts` + `metrics.ts` are an **exact mirror** of the Python
 implementation in aidream `packages/matrx-scraper/matrx_scraper/meta_metrics.py`
-— same character-width table, same limits (title 600px on desktop/mobile ·
-60/15ch, description 920px on desktop/mobile · 160/70ch), same issue strings.
-The same string yields the same
-number in the browser, in SSR, in a test, and in the scraper at crawl time.
-**Parity is enforced by `metrics.parity.test.ts`** against Python-generated
-fixtures (`__fixtures__/meta-metrics-parity.json`). Change a limit, a width, or
-an issue string → change BOTH implementations in the same unit of work and
-regenerate the fixture. Never re-declare a limit — import from `metrics.ts`.
-Google does not publish separate numeric title/description length limits; it
-truncates snippets to fit the device. Our product policy therefore uses the
-same allowance for both device evaluations while retaining both result fields
-for compatibility and future changes.
+— same character-width table, same limits (title `maxPx` 600 · 60/15ch,
+description `maxPx` 920 · 160/70ch), same issue strings. The same string yields
+the same number in the browser, in SSR, in a test, and in the scraper at crawl
+time. **Parity is enforced by `metrics.parity.test.ts`** against
+Python-generated fixtures (`__fixtures__/meta-metrics-parity.json`). Change a
+limit, a width, or an issue string → change BOTH implementations in the same
+unit of work and regenerate the fixture. Never re-declare a limit — import from
+`metrics.ts`.
+
+**ONE pixel limit per field, never a desktop/mobile pair.** Google truncates on
+rendered pixel width and publishes no separate desktop/mobile metadata rule. The
+code used to carry a desktop limit AND a mobile limit holding the same value, so
+one overflowing title emitted TWO audit issues saying the same thing (customer
+report c2fad99f, 2026-07-28). `desktopPx` / `mobilePx` / `desktopOk` / `mobileOk`
+survive only as aliases of the one `maxPx` check so persisted rows and existing
+readers keep working — **never diverge them**. The desktop vs mobile SERP
+*previews* stay: those are two real renderings, not two rules.
 
 ## Persisted metrics — contract v1
 

--- a/features/marketing/seo/serp/SerpValidation.tsx
+++ b/features/marketing/seo/serp/SerpValidation.tsx
@@ -1,10 +1,10 @@
-import { CheckCircle, XCircle, Monitor, Smartphone } from "lucide-react";
+import { CheckCircle, XCircle, Monitor } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { pctOf } from "./metrics";
 
 /**
  * Shared SERP validation chrome — the char/pixel progress bars, the
- * desktop/mobile device checks, and the compact metric chips.
+ * rendered-width verdict, and the compact metric chips.
  *
  * Used everywhere a meta title/description is scored: the calculator page's
  * Analysis panel, the SEO tool overlay's per-result detail, and the inline
@@ -60,18 +60,12 @@ function ProgressBar({
   );
 }
 
-export function SerpDeviceCheck({
-  device,
-  ok,
-}: {
-  device: "desktop" | "mobile";
-  ok: boolean;
-}) {
-  const Icon = device === "desktop" ? Monitor : Smartphone;
+/** Pass/fail for the ONE rendered-width rule (see `TITLE_LIMITS.maxPx`). */
+export function SerpWidthCheck({ ok }: { ok: boolean }) {
   return (
     <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2">
-      <Icon className="h-3.5 w-3.5 text-muted-foreground" />
-      <span className="text-xs capitalize text-foreground">{device}</span>
+      <Monitor className="h-3.5 w-3.5 text-muted-foreground" />
+      <span className="text-xs text-foreground">Rendered width</span>
       <span className="ml-auto">
         {ok ? (
           <CheckCircle className="h-4 w-4 text-success" />
@@ -83,7 +77,7 @@ export function SerpDeviceCheck({
   );
 }
 
-/** Full bars + device checks for one field (title or description). */
+/** Full bars + width verdict for one field (title or description). */
 export function SerpFieldBars({ field }: { field: SerpFieldMetrics }) {
   const charPct = pctOf(field.chars, field.charLimit);
   const pixelPct = pctOf(field.pixels, field.pixelLimit);
@@ -105,11 +99,12 @@ export function SerpFieldBars({ field }: { field: SerpFieldMetrics }) {
         label={`Characters (${field.charLimit} limit)`}
         detail={`${field.chars}/${field.charLimit}`}
       />
+      {/* ONE width verdict, not a desktop/mobile pair — Google truncates on
+          rendered pixel width with no separate device rule, so the two chips
+          always agreed and read as two independent checks (report c2fad99f).
+          `desktopOk` is the one flag; `mobileOk` is its alias. */}
       {field.desktopOk !== undefined || field.mobileOk !== undefined ? (
-        <div className="grid grid-cols-2 gap-2">
-          <SerpDeviceCheck device="desktop" ok={field.desktopOk ?? field.ok} />
-          <SerpDeviceCheck device="mobile" ok={field.mobileOk ?? field.ok} />
-        </div>
+        <SerpWidthCheck ok={field.desktopOk ?? field.mobileOk ?? field.ok} />
       ) : null}
     </div>
   );

--- a/features/marketing/seo/serp/__fixtures__/meta-metrics-parity.json
+++ b/features/marketing/seo/serp/__fixtures__/meta-metrics-parity.json
@@ -8,7 +8,9 @@
       "mobile_ok": false,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Title is empty"],
+      "issues": [
+        "Title is empty"
+      ],
       "title_ok": false
     },
     "description": {
@@ -18,7 +20,9 @@
       "mobile_ok": false,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is empty"],
+      "issues": [
+        "Description is empty"
+      ],
       "description_ok": false
     }
   },
@@ -31,7 +35,9 @@
       "mobile_ok": false,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Title is empty"],
+      "issues": [
+        "Title is empty"
+      ],
       "title_ok": false
     },
     "description": {
@@ -41,7 +47,9 @@
       "mobile_ok": false,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is empty"],
+      "issues": [
+        "Description is empty"
+      ],
       "description_ok": false
     }
   },
@@ -54,7 +62,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Title is too short (5 chars; minimum is 15)"],
+      "issues": [
+        "Title is too short (5 chars; minimum is 15)"
+      ],
       "title_ok": false
     },
     "description": {
@@ -64,7 +74,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is too short (5 chars; minimum is 70)"],
+      "issues": [
+        "Description is too short (5 chars; minimum is 70)"
+      ],
       "description_ok": false
     }
   },
@@ -87,7 +99,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is too short (55 chars; minimum is 70)"],
+      "issues": [
+        "Description is too short (55 chars; minimum is 70)"
+      ],
       "description_ok": false
     }
   },
@@ -110,7 +124,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is too short (54 chars; minimum is 70)"],
+      "issues": [
+        "Description is too short (54 chars; minimum is 70)"
+      ],
       "description_ok": false
     }
   },
@@ -125,8 +141,7 @@
       "too_short": false,
       "issues": [
         "Title is too long (129 chars; maximum is 60)",
-        "Title exceeds the desktop width limit (1148px > 600px) and may be truncated",
-        "Title exceeds the mobile width limit (1148px > 600px) and may be truncated on mobile"
+        "Title exceeds the width limit (1148px > 600px) and may be truncated"
       ],
       "title_ok": false
     },
@@ -152,8 +167,7 @@
       "too_short": false,
       "issues": [
         "Title is too long (151 chars; maximum is 60)",
-        "Title exceeds the desktop width limit (1278px > 600px) and may be truncated",
-        "Title exceeds the mobile width limit (1278px > 600px) and may be truncated on mobile"
+        "Title exceeds the width limit (1278px > 600px) and may be truncated"
       ],
       "title_ok": false
     },
@@ -179,8 +193,7 @@
       "too_short": false,
       "issues": [
         "Title is too long (71 chars; maximum is 60)",
-        "Title exceeds the desktop width limit (664px > 600px) and may be truncated",
-        "Title exceeds the mobile width limit (664px > 600px) and may be truncated on mobile"
+        "Title exceeds the width limit (664px > 600px) and may be truncated"
       ],
       "title_ok": false
     },
@@ -204,7 +217,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": false,
-      "issues": ["Title is too long (63 chars; maximum is 60)"],
+      "issues": [
+        "Title is too long (63 chars; maximum is 60)"
+      ],
       "title_ok": false
     },
     "description": {
@@ -214,7 +229,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is too short (63 chars; minimum is 70)"],
+      "issues": [
+        "Description is too short (63 chars; minimum is 70)"
+      ],
       "description_ok": false
     }
   },
@@ -237,7 +254,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is too short (35 chars; minimum is 70)"],
+      "issues": [
+        "Description is too short (35 chars; minimum is 70)"
+      ],
       "description_ok": false
     }
   },
@@ -260,7 +279,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is too short (40 chars; minimum is 70)"],
+      "issues": [
+        "Description is too short (40 chars; minimum is 70)"
+      ],
       "description_ok": false
     }
   },
@@ -275,8 +296,7 @@
       "too_short": false,
       "issues": [
         "Title is too long (64 chars; maximum is 60)",
-        "Title exceeds the desktop width limit (605px > 600px) and may be truncated",
-        "Title exceeds the mobile width limit (605px > 600px) and may be truncated on mobile"
+        "Title exceeds the width limit (605px > 600px) and may be truncated"
       ],
       "title_ok": false
     },
@@ -287,7 +307,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is too short (64 chars; minimum is 70)"],
+      "issues": [
+        "Description is too short (64 chars; minimum is 70)"
+      ],
       "description_ok": false
     }
   },
@@ -310,7 +332,9 @@
       "mobile_ok": true,
       "seo_length_ok": false,
       "too_short": true,
-      "issues": ["Description is too short (41 chars; minimum is 70)"],
+      "issues": [
+        "Description is too short (41 chars; minimum is 70)"
+      ],
       "description_ok": false
     }
   },
@@ -325,8 +349,7 @@
       "too_short": false,
       "issues": [
         "Title is too long (138 chars; maximum is 60)",
-        "Title exceeds the desktop width limit (1199px > 600px) and may be truncated",
-        "Title exceeds the mobile width limit (1199px > 600px) and may be truncated on mobile"
+        "Title exceeds the width limit (1199px > 600px) and may be truncated"
       ],
       "title_ok": false
     },

--- a/features/marketing/seo/serp/metrics.ts
+++ b/features/marketing/seo/serp/metrics.ts
@@ -25,8 +25,18 @@ export const TITLE_FONT_PX = 20;
 /** Google renders meta descriptions in ~13px Roboto/Google Sans (weight 400). */
 export const DESCRIPTION_FONT_PX = 13;
 
+/**
+ * ONE pixel limit per field, not a desktop/mobile pair. Google truncates on
+ * rendered PIXEL WIDTH and publishes no separate desktop/mobile metadata rule
+ * (customer report c2fad99f, 2026-07-28). The two limits had always carried
+ * the same value, so a single overflow emitted TWO issues saying the same
+ * thing in the audit report. `desktopPx` / `mobilePx` remain as aliases of the
+ * one `maxPx` so existing readers keep working — never diverge them.
+ */
+
 /** Meta-title limits (mirror of `calculate_meta_title_metrics`). */
 export const TITLE_LIMITS = {
+  maxPx: 600,
   desktopPx: 600,
   mobilePx: 600,
   maxChars: 60,
@@ -35,6 +45,7 @@ export const TITLE_LIMITS = {
 
 /** Meta-description limits (mirror of `calculate_meta_description_metrics`). */
 export const DESCRIPTION_LIMITS = {
+  maxPx: 920,
   desktopPx: 920,
   mobilePx: 920,
   maxChars: 160,
@@ -87,8 +98,9 @@ export function evaluateMetaTitle(title: string): MetaEvaluation {
     };
   }
   const pixelWidth = measureSerpWidth(title, "title");
-  const desktopOk = pixelWidth <= TITLE_LIMITS.desktopPx;
-  const mobileOk = pixelWidth <= TITLE_LIMITS.mobilePx;
+  const widthOk = pixelWidth <= TITLE_LIMITS.maxPx;
+  const desktopOk = widthOk;
+  const mobileOk = widthOk;
   const tooShort = charCount < TITLE_LIMITS.minChars;
   const tooLong = charCount > TITLE_LIMITS.maxChars;
   const seoLengthOk = !tooShort && !tooLong;
@@ -101,13 +113,9 @@ export function evaluateMetaTitle(title: string): MetaEvaluation {
     issues.push(
       `Title is too long (${charCount} chars; maximum is ${TITLE_LIMITS.maxChars})`,
     );
-  if (!desktopOk)
+  if (!widthOk)
     issues.push(
-      `Title exceeds the desktop width limit (${Math.round(pixelWidth)}px > ${TITLE_LIMITS.desktopPx}px) and may be truncated`,
-    );
-  if (!mobileOk)
-    issues.push(
-      `Title exceeds the mobile width limit (${Math.round(pixelWidth)}px > ${TITLE_LIMITS.mobilePx}px) and may be truncated on mobile`,
+      `Title exceeds the width limit (${Math.round(pixelWidth)}px > ${TITLE_LIMITS.maxPx}px) and may be truncated`,
     );
   return {
     pixelWidth: Math.round(pixelWidth),
@@ -116,7 +124,7 @@ export function evaluateMetaTitle(title: string): MetaEvaluation {
     mobileOk,
     seoLengthOk,
     tooShort,
-    ok: desktopOk && mobileOk && seoLengthOk,
+    ok: widthOk && seoLengthOk,
     issues,
   };
 }
@@ -136,8 +144,9 @@ export function evaluateMetaDescription(description: string): MetaEvaluation {
     };
   }
   const pixelWidth = measureSerpWidth(description, "description");
-  const desktopOk = pixelWidth <= DESCRIPTION_LIMITS.desktopPx;
-  const mobileOk = pixelWidth <= DESCRIPTION_LIMITS.mobilePx;
+  const widthOk = pixelWidth <= DESCRIPTION_LIMITS.maxPx;
+  const desktopOk = widthOk;
+  const mobileOk = widthOk;
   const tooShort = charCount < DESCRIPTION_LIMITS.minChars;
   const tooLong = charCount > DESCRIPTION_LIMITS.maxChars;
   const seoLengthOk = !tooShort && !tooLong;
@@ -150,13 +159,9 @@ export function evaluateMetaDescription(description: string): MetaEvaluation {
     issues.push(
       `Description is too long (${charCount} chars; maximum is ${DESCRIPTION_LIMITS.maxChars})`,
     );
-  if (!desktopOk)
+  if (!widthOk)
     issues.push(
-      `Description exceeds the desktop width limit (${Math.round(pixelWidth)}px > ${DESCRIPTION_LIMITS.desktopPx}px) and may be truncated`,
-    );
-  if (!mobileOk)
-    issues.push(
-      `Description exceeds the mobile width limit (${Math.round(pixelWidth)}px > ${DESCRIPTION_LIMITS.mobilePx}px) and may be truncated on mobile`,
+      `Description exceeds the width limit (${Math.round(pixelWidth)}px > ${DESCRIPTION_LIMITS.maxPx}px) and may be truncated`,
     );
   return {
     pixelWidth: Math.round(pixelWidth),
@@ -165,7 +170,7 @@ export function evaluateMetaDescription(description: string): MetaEvaluation {
     mobileOk,
     seoLengthOk,
     tooShort,
-    ok: desktopOk && mobileOk && seoLengthOk,
+    ok: widthOk && seoLengthOk,
     issues,
   };
 }

--- a/features/scraper/utils/data-utils.ts
+++ b/features/scraper/utils/data-utils.ts
@@ -317,7 +317,7 @@ class ScraperDataUtils {
     } else if (titleAnalysis.status === "Too long") {
       suggestions.push({
         type: "title",
-        message: `Page title exceeds the canonical character or rendered-width limit. Keep it at ${TITLE_LIMITS.maxChars} characters or fewer and within ${TITLE_LIMITS.desktopPx}px.`,
+        message: `Page title exceeds the canonical character or rendered-width limit. Keep it at ${TITLE_LIMITS.maxChars} characters or fewer and within ${TITLE_LIMITS.maxPx}px.`,
         priority: "high",
       });
     }

--- a/features/surfaces/manifests/cms.manifest.ts
+++ b/features/surfaces/manifests/cms.manifest.ts
@@ -7,9 +7,10 @@
  * per-site framing owned by `matrx-user/cms-site` and below) but gives an
  * agent enough to find, compare, or create a site by name before drilling in.
  *
- * The hub loads FULL `client_sites` rows (`CmsSiteService.listSites()`), so
- * the summary carries more than id/name: domain, active flag, agent write
- * policy, and whether the site has minted its public data key. The site's
+ * The hub loads SUMMARY rows (`CmsSiteService.listSites()` →
+ * `ClientSiteSummary`), which still carry more than id/name: domain, active
+ * flag, agent write policy, and whether the site has minted its public data
+ * key — but NOT `theme_config` / `navigation` / `footer_config`. The site's
  * `data_api_key` VALUE is deliberately never emitted — `has_data_api_key`
  * carries the only fact an agent needs, and the key itself belongs in the
  * Collections tab UI where it can be revealed/rotated deliberately.

--- a/features/tool-call-visualization/renderers/seo-shared/SerpToolOverlay.tsx
+++ b/features/tool-call-visualization/renderers/seo-shared/SerpToolOverlay.tsx
@@ -40,7 +40,7 @@ function entryTitleField(entry: SerpEntry): SerpFieldMetrics | null {
     chars: entry.titleChars ?? 0,
     charLimit: TITLE_LIMITS.maxChars,
     pixels: entry.titlePixels ?? 0,
-    pixelLimit: TITLE_LIMITS.desktopPx,
+    pixelLimit: TITLE_LIMITS.maxPx,
     ok: entry.titleOk ?? false,
     desktopOk: entry.titleDesktopOk,
     mobileOk: entry.titleMobileOk,
@@ -54,7 +54,7 @@ function entryDescriptionField(entry: SerpEntry): SerpFieldMetrics | null {
     chars: entry.descriptionChars ?? 0,
     charLimit: DESCRIPTION_LIMITS.maxChars,
     pixels: entry.descriptionPixels ?? 0,
-    pixelLimit: DESCRIPTION_LIMITS.desktopPx,
+    pixelLimit: DESCRIPTION_LIMITS.maxPx,
     ok: entry.descriptionOk ?? false,
     desktopOk: entry.descriptionDesktopOk,
     mobileOk: entry.descriptionMobileOk,
@@ -114,16 +114,15 @@ export function SerpToolOverlay({
               {checksTitle ? (
                 <li>
                   <strong className="text-foreground">Title:</strong> ≤
-                  {TITLE_LIMITS.maxChars} characters · ≤{TITLE_LIMITS.desktopPx}
-                  px desktop · ≤{TITLE_LIMITS.mobilePx}px mobile
+                  {TITLE_LIMITS.maxChars} characters · ≤{TITLE_LIMITS.maxPx}px
+                  rendered width
                 </li>
               ) : null}
               {checksDescription ? (
                 <li>
                   <strong className="text-foreground">Description:</strong> ≤
                   {DESCRIPTION_LIMITS.maxChars} characters · ≤
-                  {DESCRIPTION_LIMITS.desktopPx}px desktop · ≤
-                  {DESCRIPTION_LIMITS.mobilePx}px mobile
+                  {DESCRIPTION_LIMITS.maxPx}px rendered width
                 </li>
               ) : null}
             </ul>


### PR DESCRIPTION
Frontend half of a triage pass over the last 72 hours of the feedback tracker. The server half is `AI-Matrix-Engine/aidream#25`; the SEO change below spans both repos and **must ship together** — the issue strings are parity-tested against each other.

## 1. `adminListSites()` lied about its return type

Report 44350632. It was declared `Promise<ClientSite[]>` while `/api/cms/sites` `action=admin_list_sites` selected only a column subset, so `theme_config` / `navigation` / `footer_config` / `data_api_key` came back `undefined` **with no type error** — a consumer reading one silently reports "empty" for a site that has a theme. This is the same defect already fixed for `listSites()`; the admin twin was still live.

- Route: `admin_list_sites` now emits the identical SUMMARY contract as `list` — adds `favicon`, reads `data_api_key` only to compute `has_data_api_key` and strips it before the response.
- Service: `adminListSites(): Promise<ClientSiteSummary[]>`.
- Callers audited and retyped: `CmsAgentsAdminClient` plus the four panels it feeds (`ActivityFeedPanel`, `SitePageTreePanel`, `PolicyEditorPanel`, `AssetsPanel`). None read a full-row-only field, so this is pure type honesty with no behavior change.
- `PolicyEditorPanel` now narrows `adminUpdatePolicy`'s full row through the existing `toClientSiteSummary()` converter rather than widening the list back to `ClientSite`.
- Also corrected `features/surfaces/manifests/cms.manifest.ts`, which told agents the hub "loads FULL `client_sites` rows".

## 2. SEO meta carried a phantom desktop/mobile split

Report c2fad99f, from an SEO customer: "Google don't have any policy to check Meta Data separately for Desktop and Mobile. Google measure in pixels."

Correct — and it was worse than a wording problem. The desktop and mobile pixel limits always held the **same value**, so one overflowing title emitted **two** audit issues saying the same thing in the customer's report.

- `TITLE_LIMITS.maxPx` / `DESCRIPTION_LIMITS.maxPx` are the one rule; `desktopPx` / `mobilePx` / `desktopOk` / `mobileOk` survive only as aliases so persisted rows and existing readers keep working. Never diverge them.
- One issue string: `"Title exceeds the width limit (Npx > 600px) and may be truncated"`. Mirrored byte-identically in aidream's `meta_metrics.py` in the same unit of work; the parity fixture was regenerated from the Python source of truth.
- UI: the duplicated desktop/mobile pass-fail chip pair became a single **Rendered width** verdict (`SerpWidthCheck`; the now-dead `SerpDeviceCheck` was deleted rather than left as a shim), and the "≤600px desktop · ≤600px mobile" labels read "≤600px rendered width". The desktop vs mobile SERP **previews** stay — those show two real renderings, not two rules.

**Threshold values are unchanged.** The reporter also proposed 550px / 990px (ours: 600 / 920). That is a product call — 550 flags more titles, 990 flags fewer descriptions, across every audited page on live client sites — so it is raised on the report rather than changed unilaterally. It is now a one-line edit per repo if approved.

## Not verified in this environment — please run before shipping

`pnpm type-check` and the jest parity test could **not** be executed here: this sandbox cannot install frontend deps (a GitHub-tarball dependency 403s through the agent proxy, leaving `node_modules` empty). Both were attempted and failed on the install, not on the code.

What was done instead: the changes are mechanical retypes and constant renames reviewed by hand; every `TITLE_LIMITS.` / `DESCRIPTION_LIMITS.` consumer across `features/` and `app/` was grepped and none still reference `desktopPx` / `mobilePx`; and the TS and Python issue-string templates were extracted and compared directly, matching byte-for-byte with placeholders normalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rcx8v7rCFWJRiTQSCvv5ow)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin CMS API response shape and shared SEO metrics/issue strings used in audits and parity tests—coordinate release with aidream#25; no secret exposure beyond existing `has_data_api_key` pattern.
> 
> **Overview**
> **CMS admin fleet listing** now matches the owner `list` contract: `admin_list_sites` returns summary rows with `favicon`, `has_data_api_key` (key never leaves the route), and `adminListSites()` / the cms-agents admin UI are typed as `ClientSiteSummary[]`. Policy updates from `adminUpdatePolicy` are narrowed through `toClientSiteSummary()` so the in-memory list stays summary-shaped; the CMS hub manifest text is updated to say summaries, not full rows.
> 
> **SEO meta width** moves to a single rule per field (`TITLE_LIMITS.maxPx` / `DESCRIPTION_LIMITS.maxPx`). Evaluators emit one width issue instead of duplicate desktop/mobile strings; `desktopPx` / `mobileOk` remain aliases for stored payloads. UI replaces paired device chips with one **Rendered width** check and updates copy/fixtures; consumers switch to `maxPx` (calculator, scraper suggestions, SEO tool overlay). Pixel thresholds are unchanged; Python parity is expected in the paired aidream change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf4b313f73af2430cd20a403707dcce338af8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->