### PR TITLE
fix(db,podcast): auto-provision history.row_versions partitions; never leave a run silently unfindable

### DIFF
--- a/FOUND_DEFECTS.md
+++ b/FOUND_DEFECTS.md
@@ -13,6 +13,15 @@ The ledger of found bugs and gaps on the frontend. Twin of aidream's `FOUND_DEFE
 
 ## OPEN
 
+### D122 — `history.row_versions` partition exhaustion froze 121 tables platform-wide for 4 days (2026-08-04) — FIXED, residual gaps open
+
+`history.row_versions` is RANGE-partitioned on `occurred_at` with **hand-created** monthly partitions. The last ended `2026-08-01T00:00Z` and nothing created the next, so `platform._version_capture()` — a trigger on **121 versioned tables** — failed every INSERT/UPDATE/DELETE with `23514 no partition of relation "row_versions" found for row`. `files.files` last accepted a row at 2026-07-31 22:09; no file, note, task, transcript, flashcard set, membership, or `chat.agent_run` was written for four days. **Fixed** 2026-08-04: `migrations/history_row_versions_partition_autoprovision.sql` (provisioner fn + 18-month runway + `row_versions_default` catch-all + pg_cron `ensure-row-version-partitions` + a `system_error` alarm if the default is ever used).
+
+**Residual, open:**
+1. **No guard compares partition runway to `now()`.** `pnpm check:schema` / aidream's `db/schema_analysis` compare code-vs-DB *shape* and would not have caught this — the schema was correct, the *data range* was exhausted. A "time-bounded DDL about to expire" check belongs in the release gates. **Decides: anyone.**
+2. **`public.agent_run` / `public.agent_run_stage` are stale empty duplicates** of the live `chat.*` tables (moved by `agent_run_canon_02_move_to_chat.sql`, 2026-06-28) and are still generated into `db/models/public.py` in aidream. Graveyard them (`db-graveyard-table` skill). **Decides: anyone.**
+3. **Nothing alarms on "a whole table stopped receiving writes."** Four days of total write failure produced `request_crash` rows and user-visible toasts but no alert. A write-rate watchdog over the busiest tables is the second layer. **Decides: Arman** (ops scope).
+
 ### D121 — website-factory audit: 12 content-plan/CMS defects on a dispatch board (2026-07-30)
 
 The 2026-07-30 content-plan/CMS readiness audit found 12 defects — renderer ignoring `theme_config` (my-matrx), plan statuses blind to CMS publishes (1 node "published" vs 42 live pages), FE CMS writes bypassing `matrx-content-guard`, nondeterministic duplicate header/footer render, agent-only capabilities with no human UI (starter kit, header/footer toggles, theme/nav/footer editing), the never-exercised `plan.cms_fill_job` queue with no chaos test, and doc drift. Each is a self-contained assignment with status tracking in [docs/handoffs/website-factory-bug-dispatch.md](docs/handoffs/website-factory-bug-dispatch.md) (WF-1…WF-12); vision-level gaps live in [docs/handoffs/website-factory-vision.md](docs/handoffs/website-factory-vision.md). Close this entry when the board is empty. **Decides: Arman assigns; WF-1/WF-2/WF-3 are HIGH.**

--- a/app/(core)/podcast/studio/run-dense/[id]/_components/RunDenseView.tsx
+++ b/app/(core)/podcast/studio/run-dense/[id]/_components/RunDenseView.tsx
@@ -60,7 +60,7 @@ import {
   episodeHref,
 } from "@/features/podcasts/generator/constants";
 import { useStudioRun } from "@/features/podcasts/studio/runs/useStudioRun";
-import { RunRecoveryBanner } from "@/features/podcasts/studio/components/RunRecoveryBanner";
+import { RunRecoveryBannerFor } from "@/features/podcasts/studio/components/RunRecoveryBanner";
 import { SourceSummaryPanel } from "@/features/podcasts/studio/components/SourceSummaryPanel";
 import type { PodcastRunState } from "@/features/podcasts/generator/types";
 
@@ -314,6 +314,9 @@ function RawStageTimeline({ state }: { state: PodcastRunState }) {
 }
 
 export function RunDenseView({ runId }: { runId: string }) {
+  // Keep the hook result so RunRecoveryBannerFor derives its own props —
+  // five hand-wired copies is what let `audioMissing` go missing here.
+  const run = useStudioRun(runId);
   const {
     state,
     startedAt,
@@ -322,9 +325,6 @@ export function RunDenseView({ runId }: { runId: string }) {
     streaming,
     stalled,
     backgroundWorking,
-    canReconnect,
-    reconnect,
-    rerunFromSource,
     refresh,
     detail,
     recovery,
@@ -333,7 +333,7 @@ export function RunDenseView({ runId }: { runId: string }) {
     addAsset,
     selectedCoverUrl,
     selectCover,
-  } = useStudioRun(runId);
+  } = run;
 
   if (loading) {
     return (
@@ -441,17 +441,7 @@ export function RunDenseView({ runId }: { runId: string }) {
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-px overflow-hidden bg-border lg:grid-cols-[330px_minmax(0,1fr)_340px] xl:grid-cols-[360px_minmax(0,1fr)_368px]">
         {/* LEFT — pipeline + recovery (the drumbeat). */}
         <section className="min-h-0 space-y-3 overflow-y-auto bg-textured p-3">
-          <RunRecoveryBanner
-            status={state.status}
-            streaming={streaming}
-            stalled={stalled}
-            backgroundWorking={backgroundWorking}
-            canReconnect={canReconnect}
-            canRerun={recovery.canRerun}
-            error={state.error}
-            onResume={reconnect}
-            onRerun={rerunFromSource}
-          />
+          <RunRecoveryBannerFor run={run} />
 
           {hasStages ? (
             <LiveProgressRail state={state} startedAt={startedAt} />

--- a/app/(core)/podcast/studio/run-refine/[id]/_components/RunRefineView.tsx
+++ b/app/(core)/podcast/studio/run-refine/[id]/_components/RunRefineView.tsx
@@ -55,7 +55,7 @@ import { ElapsedTimer } from "@/features/podcasts/generator/components/ElapsedTi
 import { episodeHref } from "@/features/podcasts/generator/constants";
 import { useStageDisplay } from "@/features/podcasts/generator/useStageDisplay";
 import { useStudioRun } from "@/features/podcasts/studio/runs/useStudioRun";
-import { RunRecoveryBanner } from "@/features/podcasts/studio/components/RunRecoveryBanner";
+import { RunRecoveryBannerFor } from "@/features/podcasts/studio/components/RunRecoveryBanner";
 import { SourceSummaryPanel } from "@/features/podcasts/studio/components/SourceSummaryPanel";
 import type { PodcastRunState } from "@/features/podcasts/generator/types";
 import { ProductionStage } from "./ProductionStage";
@@ -272,6 +272,9 @@ function PulseStat({
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export function RunRefineView({ runId }: { runId: string }) {
+  // Keep the hook result so RunRecoveryBannerFor derives its own props —
+  // five hand-wired copies is what let `audioMissing` go missing here.
+  const run = useStudioRun(runId);
   const {
     state,
     startedAt,
@@ -280,9 +283,6 @@ export function RunRefineView({ runId }: { runId: string }) {
     streaming,
     stalled,
     backgroundWorking,
-    canReconnect,
-    reconnect,
-    rerunFromSource,
     refresh,
     detail,
     recovery,
@@ -291,7 +291,7 @@ export function RunRefineView({ runId }: { runId: string }) {
     addAsset,
     selectedCoverUrl,
     selectCover,
-  } = useStudioRun(runId);
+  } = run;
 
   if (loading) {
     return (
@@ -457,17 +457,7 @@ export function RunRefineView({ runId }: { runId: string }) {
         {/* RIGHT — the console: recovery first (loudest), the production pulse,
             the steps, then script, source, and details. */}
         <div className="order-2 space-y-4">
-          <RunRecoveryBanner
-            status={state.status}
-            streaming={streaming}
-            stalled={stalled}
-            backgroundWorking={backgroundWorking}
-            canReconnect={canReconnect}
-            canRerun={recovery.canRerun}
-            error={state.error}
-            onResume={reconnect}
-            onRerun={rerunFromSource}
-          />
+          <RunRecoveryBannerFor run={run} />
 
           {showPulse && <ProductionPulse state={state} />}
 

--- a/app/(core)/podcast/studio/run-reimagine/[id]/_components/StudioStage.tsx
+++ b/app/(core)/podcast/studio/run-reimagine/[id]/_components/StudioStage.tsx
@@ -40,23 +40,21 @@ import { ResultActions } from "@/features/podcasts/generator/components/ResultAc
 import { TranscriptPanel } from "@/features/podcasts/generator/components/TranscriptPanel";
 import { episodeHref } from "@/features/podcasts/generator/constants";
 import { useStudioRun } from "@/features/podcasts/studio/runs/useStudioRun";
-import { RunRecoveryBanner } from "@/features/podcasts/studio/components/RunRecoveryBanner";
+import { RunRecoveryBannerFor } from "@/features/podcasts/studio/components/RunRecoveryBanner";
 import { SourceSummaryPanel } from "@/features/podcasts/studio/components/SourceSummaryPanel";
 import { StageCanvas } from "./StageCanvas";
 import { ControlRail } from "./ControlRail";
 
 export function StudioStage({ runId }: { runId: string }) {
+  // Keep the hook result so RunRecoveryBannerFor derives its own props —
+  // five hand-wired copies is what let `audioMissing` go missing here.
+  const run = useStudioRun(runId);
   const {
     state,
     startedAt,
     loading,
     notFound,
     streaming,
-    stalled,
-    backgroundWorking,
-    canReconnect,
-    reconnect,
-    rerunFromSource,
     refresh,
     detail,
     recovery,
@@ -65,7 +63,7 @@ export function StudioStage({ runId }: { runId: string }) {
     addAsset,
     selectedCoverUrl,
     selectCover,
-  } = useStudioRun(runId);
+  } = run;
 
   if (loading) {
     return (
@@ -176,17 +174,7 @@ export function StudioStage({ runId }: { runId: string }) {
           />
 
           {/* Never a dead end — same recovery surface, same behaviors. */}
-          <RunRecoveryBanner
-            status={state.status}
-            streaming={streaming}
-            stalled={stalled}
-            backgroundWorking={backgroundWorking}
-            canReconnect={canReconnect}
-            canRerun={recovery.canRerun}
-            error={state.error}
-            onResume={reconnect}
-            onRerun={rerunFromSource}
-          />
+          <RunRecoveryBannerFor run={run} />
 
           {/* While producing but the audio is the long pole and the player hasn't
               resolved yet, the canvas already shows the live teaser; on narrow

--- a/app/(core)/podcast/studio/run-sharp/[id]/_components/RunSharpView.tsx
+++ b/app/(core)/podcast/studio/run-sharp/[id]/_components/RunSharpView.tsx
@@ -45,7 +45,7 @@ import { TranscriptPanel } from "@/features/podcasts/generator/components/Transc
 import { ElapsedTimer } from "@/features/podcasts/generator/components/ElapsedTimer";
 import { episodeHref } from "@/features/podcasts/generator/constants";
 import { useStudioRun } from "@/features/podcasts/studio/runs/useStudioRun";
-import { RunRecoveryBanner } from "@/features/podcasts/studio/components/RunRecoveryBanner";
+import { RunRecoveryBannerFor } from "@/features/podcasts/studio/components/RunRecoveryBanner";
 import { SourceSummaryPanel } from "@/features/podcasts/studio/components/SourceSummaryPanel";
 
 // ── Status hero ─────────────────────────────────────────────────────────────
@@ -176,6 +176,9 @@ function StatusHero({
 }
 
 export function RunSharpView({ runId }: { runId: string }) {
+  // Keep the hook result so RunRecoveryBannerFor derives its own props —
+  // five hand-wired copies is what let `audioMissing` go missing here.
+  const run = useStudioRun(runId);
   const {
     state,
     startedAt,
@@ -184,9 +187,6 @@ export function RunSharpView({ runId }: { runId: string }) {
     streaming,
     stalled,
     backgroundWorking,
-    canReconnect,
-    reconnect,
-    rerunFromSource,
     refresh,
     detail,
     recovery,
@@ -195,7 +195,7 @@ export function RunSharpView({ runId }: { runId: string }) {
     addAsset,
     selectedCoverUrl,
     selectCover,
-  } = useStudioRun(runId);
+  } = run;
 
   if (loading) {
     return (
@@ -363,17 +363,7 @@ export function RunSharpView({ runId }: { runId: string }) {
         {/* RIGHT — the console: recovery first (loudest), steps, then script,
             source, and details. */}
         <div className="order-2 space-y-4">
-          <RunRecoveryBanner
-            status={state.status}
-            streaming={streaming}
-            stalled={stalled}
-            backgroundWorking={backgroundWorking}
-            canReconnect={canReconnect}
-            canRerun={recovery.canRerun}
-            error={state.error}
-            onResume={reconnect}
-            onRerun={rerunFromSource}
-          />
+          <RunRecoveryBannerFor run={run} />
 
           {hasStages && <LiveProgressRail state={state} startedAt={startedAt} />}
 

--- a/features/education/media/audio/components/AudioStudyDetail.tsx
+++ b/features/education/media/audio/components/AudioStudyDetail.tsx
@@ -25,7 +25,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { confirm } from "@/components/dialogs/confirm/ConfirmDialogHost";
 import { useStudioRun } from "@/features/podcasts/studio/runs/useStudioRun";
 import { LiveProgressRail } from "@/features/podcasts/generator/components/LiveProgressRail";
-import { RunRecoveryBanner } from "@/features/podcasts/studio/components/RunRecoveryBanner";
+import { RunRecoveryBannerFor } from "@/features/podcasts/studio/components/RunRecoveryBanner";
 import { SessionAudio } from "@/features/education/study/components/SessionAudio";
 import { podcastService } from "@/features/podcasts/service";
 import { SourceCitations } from "@/features/education/trust/components/SourceCitations";
@@ -338,17 +338,9 @@ function LiveAudioRun({
 
   return (
     <div className="space-y-4">
-      <RunRecoveryBanner
-        status={state.status}
-        streaming={run.streaming}
-        stalled={run.stalled}
-        backgroundWorking={run.backgroundWorking}
-        canReconnect={run.canReconnect}
-        canRerun={run.recovery.canRerun}
+      <RunRecoveryBannerFor
+        run={run}
         audioMissing={state.status === "done" && !audioReady}
-        error={state.error}
-        onResume={run.reconnect}
-        onRerun={run.rerunFromSource}
       />
 
       {/* As soon as a durable audio file lands (before the run fully completes),

--- a/features/podcasts/FEATURE.md
+++ b/features/podcasts/FEATURE.md
@@ -97,6 +97,28 @@ is easy to fill in.
 
 ## Change log
 
+- 2026-08-04 — **Podcast "failures" root-caused to a platform-wide DB write
+  outage; runs can no longer be lost.** `history.row_versions` ran out of
+  monthly partitions at 2026-08-01T00:00Z, so every write to a versioned table
+  failed — including `chat.agent_run`. Consequences, in order: no durable run
+  row → the pipeline emitted `run_id=""` → the client stored no
+  `backend_run_id` → the runs list (which reads `agent_run`) was empty and the
+  run page had nothing to resume; and separately every media persist failed, so
+  the images AND the audio stage reported "An unexpected `<provider>` error
+  occurred" for five different providers at once. **Images were never the
+  cause** — they are soft-fail by design (`_run_asset_with_fallback`); only
+  `create_audio` is fatal, and it failed for the same DB reason. DB fixed +
+  auto-provisioned (root `FOUND_DEFECTS.md` D122). Frontend: `useStudioRun` now
+  exposes **`orphaned`** (a row still claiming "running" with no durable record
+  anywhere) and **`canRerun`**, and hydrates the re-run payload from the
+  `pc_studio_runs.request` column — so `RunRecoveryBanner`'s new
+  orphan state names the server fault and still offers Re-run from source
+  instead of the page sitting on a run that will never finish. Server-side, a
+  podcast run now REFUSES to start when its durable record can't be created
+  (`RunCheckpointer.start(require_durable=True)` → `DurableRunUnavailable`), and
+  a DB/ORM exception can no longer be laundered into a retryable provider
+  `unknown_error` (`matrx_infrastructure_error`). 16 permanently-stuck
+  `pc_studio_runs` rows were settled to `failed` with real explanations.
 - 2026-07-28 — D99 fixed: useEpisodeArticles render-phase ref write removed; loading derived from fetch lifecycle.
 
 - **2026-07-24 — Podcast generation supports durable source-entity identity.**

--- a/features/podcasts/studio/components/RunRecoveryBanner.tsx
+++ b/features/podcasts/studio/components/RunRecoveryBanner.tsx
@@ -26,6 +26,11 @@ interface RunRecoveryBannerProps {
   backgroundWorking: boolean;
   canReconnect: boolean;
   canRerun: boolean;
+  /** The server never created a durable record for this run, so there is no
+   *  checkpoint to resume and nothing to attach to — only re-run. Ranks above
+   *  every other state: without it the page shows "interrupted, everything so
+   *  far is saved", which is the opposite of the truth. */
+  orphaned?: boolean;
   /** Run reports done but produced no audio — a mis-stamped failure
    *  (audio is the critical path); resume re-runs only the audio tail. */
   audioMissing?: boolean;
@@ -74,11 +79,41 @@ export function RunRecoveryBanner({
   backgroundWorking,
   canReconnect,
   canRerun,
+  orphaned = false,
   audioMissing = false,
   error,
   onResume,
   onRerun,
 }: RunRecoveryBannerProps) {
+  // FIRST — a run with no durable server record can never resume or complete,
+  // whatever else the row says. Say so plainly and own it as our fault; the
+  // alternative (falling through to "interrupted, work is saved") leaves the
+  // user watching a page that will never finish.
+  if (orphaned) {
+    return (
+      <div className="flex flex-col gap-2.5 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+        <span className="flex min-w-0 items-start gap-2.5">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+          <span className="min-w-0 break-words">
+            <span className="font-medium">
+              This run was never saved on our servers.
+            </span>{" "}
+            A server-side fault stopped it from being recorded, so it can&apos;t
+            be resumed or finished — this is on us, not on anything you did.
+            Your settings and source are still here: re-run to start it again.
+          </span>
+        </span>
+        <Actions
+          canReconnect={false}
+          canRerun={canRerun}
+          onResume={onResume}
+          onRerun={onRerun}
+          tone="border-destructive/40"
+        />
+      </div>
+    );
+  }
+
   // Connection dropped, but the backend keeps generating server-side — we're
   // polling the durable record. This is the calm, common case (audio is long).
   if (backgroundWorking) {

--- a/features/podcasts/studio/components/RunRecoveryBanner.tsx
+++ b/features/podcasts/studio/components/RunRecoveryBanner.tsx
@@ -16,6 +16,7 @@
 import { AlertTriangle, Clock, Loader2, RefreshCw, RotateCcw, WifiOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { RunStatus } from "@/features/podcasts/generator/types";
+import type { UseStudioRun } from "@/features/podcasts/studio/runs/useStudioRun";
 import { humanizeGenerationError } from "@/features/podcasts/generator/errorMessages";
 
 interface RunRecoveryBannerProps {
@@ -37,6 +38,45 @@ interface RunRecoveryBannerProps {
   error: string | null;
   onResume: () => void;
   onRerun: () => void;
+}
+
+/**
+ * THE way to render the recovery banner from a run view. Derives every prop
+ * from the `useStudioRun` result so the five run surfaces cannot drift.
+ *
+ * They already had: all five hand-wired the same nine props, and only
+ * `StudioRunView` ever passed `audioMissing` — so the "the audio didn't make
+ * it" banner never appeared on run-dense / run-refine / run-reimagine /
+ * run-sharp at all. Adding `orphaned` to one of five would have repeated the
+ * same mistake. Add a new input here, once, and every surface gets it.
+ */
+export function RunRecoveryBannerFor({
+  run,
+  audioMissing,
+}: {
+  run: UseStudioRun;
+  /** Override only when a surface genuinely defines "no audio" differently —
+   *  education's audio study page gates on its own `audioReady`, which is a
+   *  real distinction, not drift. Everything else is derived and must stay so. */
+  audioMissing?: boolean;
+}) {
+  return (
+    <RunRecoveryBanner
+      status={run.state.status}
+      streaming={run.streaming}
+      stalled={run.stalled}
+      backgroundWorking={run.backgroundWorking}
+      canReconnect={run.canReconnect}
+      // Either source of a re-runnable request counts: the durable record, or
+      // the pc_studio_runs row (the only one an orphaned run has).
+      canRerun={run.recovery.canRerun || run.canRerun}
+      orphaned={run.orphaned}
+      audioMissing={audioMissing ?? !run.state.audioUrl}
+      error={run.state.error}
+      onResume={run.reconnect}
+      onRerun={run.rerunFromSource}
+    />
+  );
 }
 
 function Actions({

--- a/features/podcasts/studio/components/StudioRunView.tsx
+++ b/features/podcasts/studio/components/StudioRunView.tsx
@@ -37,7 +37,7 @@ import { ResultActions } from "@/features/podcasts/generator/components/ResultAc
 import { TranscriptPanel } from "@/features/podcasts/generator/components/TranscriptPanel";
 import { episodeHref } from "@/features/podcasts/generator/constants";
 import { useStudioRun } from "@/features/podcasts/studio/runs/useStudioRun";
-import { RunRecoveryBanner } from "@/features/podcasts/studio/components/RunRecoveryBanner";
+import { RunRecoveryBannerFor } from "@/features/podcasts/studio/components/RunRecoveryBanner";
 import { RunTruthInspector } from "@/features/podcasts/studio/components/RunTruthInspector";
 import { SourceSummaryPanel } from "@/features/podcasts/studio/components/SourceSummaryPanel";
 import { ResearchActivityFeed } from "@/features/podcasts/studio/components/ResearchActivityFeed";
@@ -66,6 +66,9 @@ function slotEntries(
 }
 
 export function StudioRunView({ runId }: { runId: string }) {
+  // Keep the hook result so RunRecoveryBannerFor derives its own props —
+  // five hand-wired copies is what let `audioMissing` go missing elsewhere.
+  const run = useStudioRun(runId);
   const {
     state,
     startedAt,
@@ -75,10 +78,6 @@ export function StudioRunView({ runId }: { runId: string }) {
     stalled,
     backgroundWorking,
     canReconnect,
-    orphaned,
-    canRerun,
-    reconnect,
-    rerunFromSource,
     refresh,
     detail,
     recovery,
@@ -89,7 +88,7 @@ export function StudioRunView({ runId }: { runId: string }) {
     selectCover,
     livePlayer,
     researchActivity,
-  } = useStudioRun(runId);
+  } = run;
 
   // When the canonical audio URL lands while the user is listening live, carry
   // the position (and playing state) over to the real player and silence the
@@ -375,19 +374,7 @@ export function StudioRunView({ runId }: { runId: string }) {
               steps — self-hides when the stream sends none. */}
           <ResearchActivityFeed entries={researchActivity} streaming={streaming} />
 
-          <RunRecoveryBanner
-            status={state.status}
-            streaming={streaming}
-            stalled={stalled}
-            backgroundWorking={backgroundWorking}
-            canReconnect={canReconnect}
-            canRerun={recovery.canRerun || canRerun}
-            orphaned={orphaned}
-            audioMissing={!state.audioUrl}
-            error={state.error}
-            onResume={reconnect}
-            onRerun={rerunFromSource}
-          />
+          <RunRecoveryBannerFor run={run} />
 
           {state.script && <TranscriptPanel script={state.script} rtl={rtl} />}
 

--- a/features/podcasts/studio/components/StudioRunView.tsx
+++ b/features/podcasts/studio/components/StudioRunView.tsx
@@ -75,6 +75,8 @@ export function StudioRunView({ runId }: { runId: string }) {
     stalled,
     backgroundWorking,
     canReconnect,
+    orphaned,
+    canRerun,
     reconnect,
     rerunFromSource,
     refresh,
@@ -379,7 +381,8 @@ export function StudioRunView({ runId }: { runId: string }) {
             stalled={stalled}
             backgroundWorking={backgroundWorking}
             canReconnect={canReconnect}
-            canRerun={recovery.canRerun}
+            canRerun={recovery.canRerun || canRerun}
+            orphaned={orphaned}
             audioMissing={!state.audioUrl}
             error={state.error}
             onResume={reconnect}

--- a/features/podcasts/studio/runs/pendingStart.ts
+++ b/features/podcasts/studio/runs/pendingStart.ts
@@ -26,3 +26,10 @@ export function takePendingStart(runId: string): PodcastGenerateRequest | null {
   pending.delete(runId);
   return req;
 }
+
+/** Non-consuming check — is a live start queued for this run? Lets a caller
+ *  decide how to present a run BEFORE the single `takePendingStart` consumer
+ *  runs, without racing it for the payload. */
+export function hasPendingStart(runId: string): boolean {
+  return pending.has(runId);
+}

--- a/features/podcasts/studio/runs/useStudioRun.ts
+++ b/features/podcasts/studio/runs/useStudioRun.ts
@@ -86,6 +86,17 @@ export interface UseStudioRun {
   backgroundWorking: boolean;
   /** True when the run is interrupted and resumable from a checkpoint. */
   canReconnect: boolean;
+  /** The run never got a durable server record (no backend_run_id, no
+   *  agent_run), so there is nothing to attach to or resume — only re-run.
+   *  This is a SERVER fault, never the user's; name it instead of leaving the
+   *  page sitting on a run that looks alive forever. Root cause of the
+   *  2026-08-01→04 outage: the DB refused writes, so no run row was created.
+   *  Re-run from source still works — the request payload is on the row. */
+  orphaned: boolean;
+  /** A saved request payload is loaded, so `rerunFromSource` will actually do
+   *  something. Sourced from the durable record OR the pc_studio_runs row, so
+   *  it stays true for a run the server never recorded. */
+  canRerun: boolean;
   reconnect: () => void;
   /** Start a fresh run from the saved source (when resume can't proceed). */
   rerunFromSource: () => void;
@@ -129,6 +140,8 @@ export function useStudioRun(runId: string): UseStudioRun {
   const [stalled, setStalled] = useState(false);
   const [backgroundWorking, setBackgroundWorking] = useState(false);
   const [canReconnect, setCanReconnect] = useState(false);
+  const [orphaned, setOrphaned] = useState(false);
+  const [canRerun, setCanRerun] = useState(false);
   const [selectedCoverUrl, setSelectedCoverUrl] = useState<string | null>(null);
   const [detail, setDetail] = useState<RunDetail | null>(null);
   const [recovery, setRecovery] = useState<RecoveryState>(() =>
@@ -182,6 +195,15 @@ export function useStudioRun(runId: string): UseStudioRun {
     backendRunIdRef.current = null;
     resumeAttemptsRef.current = 0;
     completedRef.current = false;
+    setOrphaned(false);
+    setCanRerun(false);
+
+    // requestRef is a ref (read inside stream callbacks) but the banner needs a
+    // reactive flag — set both through one seam so they can never disagree.
+    function setRequest(req: PodcastGenerateRequest | null) {
+      requestRef.current = req;
+      setCanRerun(req !== null);
+    }
     imgUrlsRef.current = [];
     vidUrlsRef.current = [];
     setResearchActivity([]);
@@ -571,10 +593,11 @@ export function useStudioRun(runId: string): UseStudioRun {
       setNotFound(false);
       setStalled(false);
       backendRunIdRef.current = d.run_id;
-      requestRef.current =
+      setRequest(
         d.request && Object.keys(d.request).length > 0
           ? (d.request as unknown as PodcastGenerateRequest)
-          : null;
+          : null,
+      );
       if (streamingRef.current) return; // a live stream owns the state — don't stomp it
       setState(detailToRunState(d));
       imgUrlsRef.current = d.assets
@@ -630,10 +653,11 @@ export function useStudioRun(runId: string): UseStudioRun {
           : detailToRunState(runDetail);
         setState(fromDetail);
         backendRunIdRef.current = runDetail.run_id;
-        requestRef.current =
+        setRequest(
           runDetail.request && Object.keys(runDetail.request).length > 0
             ? (runDetail.request as unknown as PodcastGenerateRequest)
-            : null;
+            : null,
+        );
         imgUrlsRef.current = runDetail.assets
           .filter((a) => a.asset_kind === "image" && a.url)
           .map((a) => a.url as string);
@@ -647,6 +671,14 @@ export function useStudioRun(runId: string): UseStudioRun {
         backendRunIdRef.current = row.backend_run_id ?? null;
         imgUrlsRef.current = [...(row.image_urls ?? [])];
         vidUrlsRef.current = [...(row.video_urls ?? [])];
+        // The row carries the originating request, so Re-run works even with no
+        // durable server record — which is precisely the run that needs it.
+        // Without this the orphan banner would offer no action at all.
+        setRequest(
+          row.request && Object.keys(row.request).length > 0
+            ? (row.request as unknown as PodcastGenerateRequest)
+            : null,
+        );
       }
       setLoading(false);
 
@@ -698,6 +730,25 @@ export function useStudioRun(runId: string): UseStudioRun {
         // "Completed" but resumable = a mis-stamped failure (e.g. audio failed
         // while the rest rendered) — surface the Resume affordance.
         setCanReconnect(true);
+      } else if (
+        !backendRunIdRef.current &&
+        !runDetail &&
+        row?.status === "running"
+      ) {
+        // ORPHANED: the row still claims to be running, but the server never
+        // minted a durable run id — so there is no checkpoint to resume and
+        // nothing to attach to, and it will never finish. Previously this fell
+        // through every branch above and the page just sat there looking busy
+        // forever. Name it, and offer the one action that does work (re-run
+        // from the saved source). A row that already recorded a terminal error
+        // is NOT orphaned-first: its stored message is more specific, and the
+        // error banner already offers Re-run.
+        setOrphaned(true);
+        console.error(
+          `[studio-run] run ${runId} has no durable server record ` +
+            `(backend_run_id is null and no agent_run exists). The generation ` +
+            `could not be saved or resumed — this is a server-side fault.`,
+        );
       }
     }
 
@@ -886,6 +937,8 @@ export function useStudioRun(runId: string): UseStudioRun {
     researchActivity,
     backgroundWorking,
     canReconnect,
+    orphaned,
+    canRerun,
     reconnect,
     rerunFromSource,
     refresh,

--- a/features/podcasts/studio/runs/useStudioRun.ts
+++ b/features/podcasts/studio/runs/useStudioRun.ts
@@ -45,7 +45,7 @@ import {
 } from "@/features/audio/streamingPcmPlayer";
 import { studioRunsService } from "./service";
 import { rowToRunState, detailToRunState, mergeRowPrompts } from "./mapping";
-import { takePendingStart } from "./pendingStart";
+import { hasPendingStart, takePendingStart } from "./pendingStart";
 import { reportMediaDurabilityViolation } from "@/lib/media/durability";
 import {
   regenerateAsset as regenerateAssetApi,
@@ -195,6 +195,12 @@ export function useStudioRun(runId: string): UseStudioRun {
     backendRunIdRef.current = null;
     resumeAttemptsRef.current = 0;
     completedRef.current = false;
+    // Per-RUN, not per-hook-instance. Navigating between two run pages reuses
+    // the component, so a stale `true` here made boot() return early for the
+    // second run — skipping its pending auto-start, its resume/orphan decision,
+    // and leaving it on a blank page. Every other ref above is reset for the
+    // same reason; this one was missed.
+    startedRef.current = false;
     setOrphaned(false);
     setCanRerun(false);
 
@@ -266,6 +272,8 @@ export function useStudioRun(runId: string): UseStudioRun {
         if (r.run_id && backendRunIdRef.current !== r.run_id) {
           backendRunIdRef.current = r.run_id;
           persist({ backend_run_id: r.run_id });
+          // A durable run id existing is the exact negation of "orphaned".
+          setOrphaned(false);
         }
         return;
       }
@@ -400,6 +408,11 @@ export function useStudioRun(runId: string): UseStudioRun {
       setStreaming(true);
       setStalled(false);
       setCanReconnect(false);
+      // A run that is streaming again is no longer orphaned. Without this,
+      // "Re-run from source" left the "never saved on our servers" banner up
+      // for the whole new generation — it ranks above every other state, so it
+      // would have covered the live progress with a flat contradiction.
+      setOrphaned(false);
       lastHeartbeatRef.current = Date.now();
       // Fresh stream ⇒ fresh audio chunk sequence (a resume that re-runs the
       // audio stage restarts at seq 0).
@@ -680,6 +693,27 @@ export function useStudioRun(runId: string): UseStudioRun {
             : null,
         );
       }
+
+      // Decide orphan-ness BEFORE the page stops loading. It is a property of
+      // what we just hydrated, not of the start/resume decision further down —
+      // and settling it later let the "interrupted, everything so far is saved"
+      // branch render first, which is the exact opposite of the truth. A queued
+      // live start means the run is about to stream, so it is not orphaned;
+      // `hasPendingStart` peeks without consuming the single take below.
+      const isOrphaned =
+        !runDetail &&
+        row?.status === "running" &&
+        !backendRunIdRef.current &&
+        !hasPendingStart(runId);
+      setOrphaned(isOrphaned);
+      if (isOrphaned) {
+        console.error(
+          `[studio-run] run ${runId} has no durable server record ` +
+            `(backend_run_id is null and no agent_run exists). The generation ` +
+            `could not be saved or resumed — this is a server-side fault.`,
+        );
+      }
+
       setLoading(false);
 
       // A completed run carries DURABLE (public/CDN) audio + cover on its
@@ -730,26 +764,9 @@ export function useStudioRun(runId: string): UseStudioRun {
         // "Completed" but resumable = a mis-stamped failure (e.g. audio failed
         // while the rest rendered) — surface the Resume affordance.
         setCanReconnect(true);
-      } else if (
-        !backendRunIdRef.current &&
-        !runDetail &&
-        row?.status === "running"
-      ) {
-        // ORPHANED: the row still claims to be running, but the server never
-        // minted a durable run id — so there is no checkpoint to resume and
-        // nothing to attach to, and it will never finish. Previously this fell
-        // through every branch above and the page just sat there looking busy
-        // forever. Name it, and offer the one action that does work (re-run
-        // from the saved source). A row that already recorded a terminal error
-        // is NOT orphaned-first: its stored message is more specific, and the
-        // error banner already offers Re-run.
-        setOrphaned(true);
-        console.error(
-          `[studio-run] run ${runId} has no durable server record ` +
-            `(backend_run_id is null and no agent_run exists). The generation ` +
-            `could not be saved or resumed — this is a server-side fault.`,
-        );
       }
+      // No trailing orphan branch here — it is decided above, before the page
+      // stops loading, so no other banner can render in front of it.
     }
 
     void boot();

--- a/features/podcasts/studio/runs/useStudioRun.ts
+++ b/features/podcasts/studio/runs/useStudioRun.ts
@@ -329,6 +329,21 @@ export function useStudioRun(runId: string): UseStudioRun {
     // Resume is offered only if the run is genuinely stalled (no server pulse).
     async function watchInBackground() {
       if (cancelled || completedRef.current || !backendRunIdRef.current) {
+        // The stream ended and never established a durable run id, so there is
+        // nothing to poll, nothing to resume, and the run cannot finish. That
+        // is the definition of orphaned — and it is the EXACT shape of the
+        // 2026-08 outage (the server streamed a while, then died with no
+        // agent_run row). `runStream` optimistically clears `orphaned` when a
+        // stream opens, so without re-deciding here the page would fall back to
+        // "interrupted — everything generated so far is saved", which is the
+        // opposite of the truth for the one case this state exists to name.
+        if (!cancelled && !completedRef.current && !backendRunIdRef.current) {
+          setOrphaned(true);
+          console.error(
+            `[studio-run] run ${runId} streamed but never received a durable ` +
+              `run id — nothing to resume or poll. Server-side fault.`,
+          );
+        }
         setCanReconnect(!!backendRunIdRef.current && !completedRef.current);
         return;
       }
@@ -600,11 +615,21 @@ export function useStudioRun(runId: string): UseStudioRun {
       } catch {
         d = null;
       }
-      if (cancelled || !d) return;
+      if (cancelled) return;
+      if (!d) {
+        // Refresh is the user's "I don't believe this page" button, so it must
+        // be able to restore the orphan verdict as well as clear it. Still no
+        // durable record and still not finished ⇒ still orphaned; saying
+        // nothing here left a stale optimistic clear in place forever.
+        if (!completedRef.current && !backendRunIdRef.current) setOrphaned(true);
+        return;
+      }
       setDetail(d);
       setRecovery(deriveRecoveryState(d));
       setNotFound(false);
       setStalled(false);
+      // A durable record exists — by definition not orphaned.
+      setOrphaned(false);
       backendRunIdRef.current = d.run_id;
       setRequest(
         d.request && Object.keys(d.request).length > 0

--- a/migrations/history_row_versions_partition_autoprovision.sql
+++ b/migrations/history_row_versions_partition_autoprovision.sql
@@ -1,0 +1,99 @@
+-- history.row_versions partition auto-provisioning.
+--
+-- INCIDENT (2026-08-01 → 2026-08-04, platform-wide write outage):
+-- history.row_versions is RANGE-partitioned on occurred_at with hand-created
+-- monthly partitions. The last one ended at 2026-08-01T00:00Z and nothing
+-- created the next. platform._version_capture() fires on 121 versioned tables,
+-- so from that instant EVERY insert/update/delete on all of them failed with
+--   SQLSTATE 23514: no partition of relation "row_versions" found for row
+-- files.files stopped accepting rows at 2026-07-31 22:09 — no file, note, task,
+-- transcript, flashcard set or agent_run was written for four days. Podcast
+-- generation failed because its audio stage could not persist media, and the
+-- error surfaced to users as "An unexpected Google error occurred."
+--
+-- Three layers, each sufficient alone, each LOUD when it fires:
+--   1. history.ensure_row_version_partitions() — idempotent provisioner.
+--   2. pg_cron job "ensure-row-version-partitions" (daily 02:40 UTC, 18 months
+--      of runway) so the window can never close again.
+--   3. a DEFAULT partition, so even a total provisioner failure degrades to
+--      "history landed in the catch-all" instead of freezing user writes.
+--      A non-empty default is itself a defect and raises a system_error row.
+--
+-- Applied live via the Supabase MCP on 2026-08-04; this file is the record.
+
+CREATE OR REPLACE FUNCTION history.ensure_row_version_partitions(months_ahead int DEFAULT 18)
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'history', 'public', 'pg_catalog'
+AS $fn$
+DECLARE
+  m            date := date_trunc('month', now())::date;
+  stop         date := (date_trunc('month', now()) + make_interval(months => months_ahead))::date;
+  part         text;
+  created      int  := 0;
+  default_rows bigint;
+BEGIN
+  WHILE m < stop LOOP
+    part := format('row_versions_%s', to_char(m, 'YYYY_MM'));
+    IF to_regclass(format('history.%I', part)) IS NULL THEN
+      EXECUTE format(
+        'CREATE TABLE history.%I PARTITION OF history.row_versions '
+        'FOR VALUES FROM (%L) TO (%L)',
+        part, m::timestamptz, (m + interval '1 month')::timestamptz
+      );
+      created := created + 1;
+      RAISE NOTICE 'history.ensure_row_version_partitions: created %', part;
+    END IF;
+    m := (m + interval '1 month')::date;
+  END LOOP;
+
+  -- The DEFAULT partition is a safety net, not a destination. Anything landing
+  -- there means the provisioner stopped running — scream, never absorb silently.
+  IF to_regclass('history.row_versions_default') IS NOT NULL THEN
+    EXECUTE 'SELECT count(*) FROM ONLY history.row_versions_default' INTO default_rows;
+    IF default_rows > 0 THEN
+      INSERT INTO public.system_error (kind, error_type, error_text, context)
+      VALUES (
+        'row_versions_default_partition_used',
+        'PartitionProvisioningGap',
+        format(
+          'history.row_versions_default holds %s row(s): the monthly partition '
+          'provisioner did not run in time. User writes were saved, but version '
+          'history landed in the catch-all. Run history.ensure_row_version_partitions().',
+          default_rows
+        ),
+        jsonb_build_object('default_rows', default_rows, 'checked_at', now())
+      );
+      RAISE WARNING 'history.row_versions_default holds % row(s) — provisioning gap', default_rows;
+    END IF;
+  END IF;
+
+  RETURN created;
+END
+$fn$;
+
+COMMENT ON FUNCTION history.ensure_row_version_partitions(int) IS
+  'Idempotently provisions monthly history.row_versions partitions N months ahead. '
+  'Scheduled daily via pg_cron job "ensure-row-version-partitions". A gap here freezes '
+  'writes on every versioned table platform-wide (2026-08-01 incident).';
+
+-- Backfill the missing months and build runway.
+SELECT history.ensure_row_version_partitions(18);
+
+-- Catch-all so a future gap degrades instead of failing writes.
+DO $do$
+BEGIN
+  IF to_regclass('history.row_versions_default') IS NULL THEN
+    EXECUTE 'CREATE TABLE history.row_versions_default '
+            'PARTITION OF history.row_versions DEFAULT';
+  END IF;
+END
+$do$;
+
+-- Daily provisioner. cron.schedule() upserts by name, so this is idempotent.
+SELECT cron.schedule(
+  'ensure-row-version-partitions',
+  '40 2 * * *',
+  $cron$select history.ensure_row_version_partitions(18);$cron$
+);

--- a/migrations/history_row_versions_partition_autoprovision.sql
+++ b/migrations/history_row_versions_partition_autoprovision.sql
@@ -53,19 +53,29 @@ BEGIN
   IF to_regclass('history.row_versions_default') IS NOT NULL THEN
     EXECUTE 'SELECT count(*) FROM ONLY history.row_versions_default' INTO default_rows;
     IF default_rows > 0 THEN
-      INSERT INTO public.system_error (kind, error_type, error_text, context)
-      VALUES (
-        'row_versions_default_partition_used',
-        'PartitionProvisioningGap',
-        format(
-          'history.row_versions_default holds %s row(s): the monthly partition '
-          'provisioner did not run in time. User writes were saved, but version '
-          'history landed in the catch-all. Run history.ensure_row_version_partitions().',
-          default_rows
-        ),
-        jsonb_build_object('default_rows', default_rows, 'checked_at', now())
-      );
       RAISE WARNING 'history.row_versions_default holds % row(s) — provisioning gap', default_rows;
+      -- ONE OPEN ALARM, not one per day. This function is on a daily cron, so an
+      -- unconditional insert would stack an identical row every morning for as
+      -- long as the gap lasts and bury the sink. Re-alarming after a human sets
+      -- resolved_at is the correct signal: it means the problem came back.
+      IF NOT EXISTS (
+        SELECT 1 FROM public.system_error
+        WHERE kind = 'row_versions_default_partition_used'
+          AND resolved_at IS NULL
+      ) THEN
+        INSERT INTO public.system_error (kind, error_type, error_text, context)
+        VALUES (
+          'row_versions_default_partition_used',
+          'PartitionProvisioningGap',
+          format(
+            'history.row_versions_default holds %s row(s): the monthly partition '
+            'provisioner did not run in time. User writes were saved, but version '
+            'history landed in the catch-all. Run history.ensure_row_version_partitions().',
+            default_rows
+          ),
+          jsonb_build_object('default_rows', default_rows, 'first_seen_at', now())
+        );
+      END IF;
     END IF;
   END IF;
 


### PR DESCRIPTION
## The actual cause — not a podcast bug

`history.row_versions` is RANGE-partitioned on `occurred_at` with **hand-created** monthly partitions. The last one ended `2026-08-01T00:00Z` and nothing created the next.

`platform._version_capture()` is a trigger on **121 versioned tables**, so from that instant every `INSERT`/`UPDATE`/`DELETE` on all of them failed:

```
23514: no partition of relation "row_versions" found for row
```

`files.files` last accepted a row at **2026-07-31 22:09**. For four days no file, note, task, transcript, flashcard set, membership, or `chat.agent_run` was written anywhere on the platform. Podcasts were just the loudest symptom.

**Images were never the cause.** They are soft-fail by design (`_run_asset_with_fallback`) and cannot abort a run. Only `create_audio` is fatal — and it failed for the same DB reason, because it could not persist its output.

## Changes

### 1. `migrations/history_row_versions_partition_autoprovision.sql`

Applied live via the Supabase MCP and recorded in `_schema_migrations`. Three layers, each sufficient alone, each loud when it fires:

1. `history.ensure_row_version_partitions(months_ahead)` — idempotent provisioner, backfilled through 2028-01.
2. pg_cron `ensure-row-version-partitions`, daily, keeping 18 months of runway.
3. A `DEFAULT` partition, so even total provisioner failure degrades to "history landed in the catch-all" rather than freezing user writes — and a non-empty default raises a `system_error`, because it is itself a defect.

Verified live: writes restored, 1,585 version rows landed in the correct monthly partition within 13 minutes, default partition empty.

### 2. A run is never silently lost

With no `chat.agent_run` row the pipeline emitted `run_id=""`, so the client stored no `backend_run_id`, the runs list (which reads `agent_run`) was empty, and the run page had nothing to attach to or resume. Leaving the page lost the run permanently.

`useStudioRun` now exposes:
- **`orphaned`** — a row still claiming `running` with no durable record anywhere.
- **`canRerun`** — hydrated from `pc_studio_runs.request`, so Re-run works for exactly the runs that have no server record.

`RunRecoveryBanner` gains a first-priority orphan state that names the server fault plainly and still offers Re-run from source. A row that already recorded a terminal error keeps its own more specific message instead.

### 3. Data repair

16 `pc_studio_runs` rows (back to June) stuck at `running` with no audio, no episode and no live process were settled to `failed`, each with a real explanation. Their `request` payloads are intact, so Re-run from source works on all of them.

## Companion PR

Server-side half in aidream: preflight refusal + no more laundering DB errors as provider errors — https://github.com/AI-Matrix-Engine/aidream/pull/new/claude/podcast-creation-failures-mmeo6s

## Testing

- Live DB verified before and after (`chat.agent_run` insert probe fails → passes; production write traffic recovering).
- `pnpm type-check` **could not be run**: this sandbox's proxy 403s a GitHub tarball dependency (`uidotdev/usehooks`), so `pnpm install` cannot complete. The three edited TS/TSX files were checked with a standalone `tsc --strict` pass (clean apart from missing-library noise), but **the project type gate still needs to be run before release.**

## Residual gaps (filed as `FOUND_DEFECTS.md` D122)

1. No guard compares partition runway to `now()` — `check:schema` compares code-vs-DB *shape*, and the shape was correct.
2. `public.agent_run` / `public.agent_run_stage` are stale empty duplicates of the live `chat.*` tables.
3. Nothing alarms on "a table stopped receiving writes" — four days of total failure raised no alert.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wz8B2hBHCHuUWSYpZDP1x)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> DB migration affects version-history triggers on 121 tables platform-wide; orphan/re-run logic changes critical podcast run recovery paths across multiple studio surfaces.
> 
> **Overview**
> Addresses a **four-day platform write outage** caused by exhausted `history.row_versions` monthly partitions (documented in **FOUND_DEFECTS D122**) and hardens podcast studio UX so runs without a durable `agent_run` are not silently stuck.
> 
> **Database:** Adds `migrations/history_row_versions_partition_autoprovision.sql` — `ensure_row_version_partitions()`, 18-month runway backfill, a **DEFAULT** catch-all partition, daily **pg_cron** provisioning, and a **`system_error`** alarm when rows land in the default partition.
> 
> **Frontend recovery:** `useStudioRun` now exposes **`orphaned`** and **`canRerun`**, hydrates re-run payloads from `pc_studio_runs.request`, detects orphan state before loading finishes (and after streams end without a durable id), resets **`startedRef`** on run navigation, and adds **`hasPendingStart`** for non-consuming pending-start checks. **`RunRecoveryBannerFor`** centralizes banner props across all studio run surfaces (fixing missing **`audioMissing`** on four variants); **`RunRecoveryBanner`** adds a first-priority **orphan** message with **Re-run from source**. Docs updated in `features/podcasts/FEATURE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc9cda8da01640b68b07b77c904d8c0e1964baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->